### PR TITLE
[ROC-38] Use single transaction for inserting data in table and audit table

### DIFF
--- a/rococo/data/base.py
+++ b/rococo/data/base.py
@@ -16,6 +16,11 @@ class DbAdapter(ABC):
         pass
 
     @abstractmethod
+    def run_transaction(self, operations_list: List[Any]):
+        """Execute a list of queries / operations as a transaction."""
+        pass
+
+    @abstractmethod
     def execute_query(self, sql: str, _vars: Dict[str, Any] = None) -> Any:
         """Executes a raw SQL query against the DB."""
         pass
@@ -37,8 +42,18 @@ class DbAdapter(ABC):
         pass
 
     @abstractmethod
+    def get_move_entity_to_audit_table_query(self, table, entity_id):
+        """Returns query to move entity by entity_id to audit table."""
+        pass
+
+    @abstractmethod
     def move_entity_to_audit_table(self, table_name: str, entity_id: str):
         """Inserts the existing entities by entity_id in {table_name}_audit table."""
+        pass
+
+    @abstractmethod
+    def get_save_query(self, table: str, data: Dict[str, Any]):
+        """Returns query to save a data record in the table."""
         pass
 
     @abstractmethod

--- a/rococo/models/versioned_model.py
+++ b/rococo/models/versioned_model.py
@@ -147,6 +147,8 @@ class VersionedModel:
                         results[key] = str(value)
                 elif isinstance(value, str):
                     results[key] = value
+                elif isinstance(value, dict):
+                    results[key] = str(value.get('entity_id')) if convert_uuids else value.get('entity_id')
                 else:
                     raise NotImplementedError
 

--- a/rococo/repositories/mysql/mysql_repository.py
+++ b/rococo/repositories/mysql/mysql_repository.py
@@ -1,8 +1,9 @@
 """MySqlDbRepository class"""
 
-import re
 from dataclasses import fields
 from datetime import datetime
+import json
+import re
 from typing import Any, Dict, List, Type, Union
 from uuid import UUID
 

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='rococo',
-    version='1.0.8',
+    version='1.0.9',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/base_repository_test.py
+++ b/tests/base_repository_test.py
@@ -108,8 +108,9 @@ class TestBaseRepository:
         """
         Test saving a model instance
         """
-        mock_adapter.save.return_value = True
-        mock_adapter.move_entity_to_audit_table.return_value = None
+        mock_adapter.get_save_query.return_value = "", ()
+        mock_adapter.get_move_entity_to_audit_table_query.return_value = "", ()
+        mock_adapter.run_transaction.return_value = True
 
         model_instance = TestVersionedModel()
         result = repository.save(model_instance)
@@ -118,7 +119,7 @@ class TestBaseRepository:
         assert result.entity_id is not None
         assert result.version is not None
 
-        mock_adapter.save.assert_called_with('testversionedmodel', {})
+        mock_adapter.run_transaction.assert_called_with([("", ()), ("", ())])
         mock_adapter.__enter__.assert_called()
         mock_adapter.__exit__.assert_called()
 
@@ -126,15 +127,17 @@ class TestBaseRepository:
         """
         Test deleting by id
         """
-        mock_adapter.save.return_value = True
-        mock_adapter.move_entity_to_audit_table.return_value = None
+        mock_adapter.get_save_query.return_value = "", ()
+        mock_adapter.get_move_entity_to_audit_table_query.return_value = "", ()
+        mock_adapter.run_transaction.return_value = True
 
         model_instance = TestVersionedModel()
         result = repository.delete(model_instance)
 
         assert result is model_instance
         assert model_instance.active == False
-        mock_adapter.save.assert_called_with('testversionedmodel', {})
+
+        mock_adapter.run_transaction.assert_called_with([("", ()), ("", ())])
         mock_adapter.__enter__.assert_called()
         mock_adapter.__exit__.assert_called()
 
@@ -142,14 +145,15 @@ class TestBaseRepository:
         """
         Test saving and sending message
         """
-        mock_adapter.save.return_value = True
-        mock_adapter.move_entity_to_audit_table.return_value = None
+        mock_adapter.get_save_query.return_value = "", ()
+        mock_adapter.get_move_entity_to_audit_table_query.return_value = "", ()
+        mock_adapter.run_transaction.return_value = True
 
         model_instance = TestVersionedModel()
         result = repository.save(model_instance, True)
 
         assert result is model_instance
-        mock_adapter.save.assert_called_with('testversionedmodel', {})
+        mock_adapter.run_transaction.assert_called_with([("", ()), ("", ())])
         mock_adapter.__enter__.assert_called()
         mock_adapter.__exit__.assert_called()
 

--- a/tests/surreal_db_repository_test.py
+++ b/tests/surreal_db_repository_test.py
@@ -43,7 +43,9 @@ class SurrealDbRepositoryTestCase(unittest.TestCase):
         test that saving sends the message
         """
         # Set up the mock to return a successful save
-        self.db_adapter_mock.save.return_value = True
+        self.db_adapter_mock.get_save_query.return_value = "", ()
+        self.db_adapter_mock.get_move_entity_to_audit_table_query.return_value = "", ()
+        self.db_adapter_mock.run_transaction.return_value = True
 
         # Call the save method
         saved_instance = self.repository.save(self.model_instance, send_message=True)
@@ -51,9 +53,7 @@ class SurrealDbRepositoryTestCase(unittest.TestCase):
         surrealdb_dict = saved_instance.as_dict(convert_datetime_to_iso_string=True)
         surrealdb_dict['id'] = surrealdb_dict.pop('entity_id')
         # Assert the save method on the adapter was called once with the correct arguments
-        self.db_adapter_mock.save.assert_called_once_with(
-            "versionedmodelhelper", {**surrealdb_dict, 'id': f'{self.model_instance.__class__.__name__.lower()}:`{surrealdb_dict["id"]}`'}
-        )
+        self.db_adapter_mock.run_transaction.assert_called_once_with([("", ()), ("", ())])
 
         # Assert the send_message method was called once with the correct arguments
         self.message_adapter_mock.send_message.assert_called_once_with(
@@ -65,13 +65,15 @@ class SurrealDbRepositoryTestCase(unittest.TestCase):
         Test save without sending message
         """
         # Set up the mock to return a successful save
-        self.db_adapter_mock.save.return_value = True
+        self.db_adapter_mock.get_save_query.return_value = "", ()
+        self.db_adapter_mock.get_move_entity_to_audit_table_query.return_value = "", ()
+        self.db_adapter_mock.run_transaction.return_value = True
 
         # Call the save method with send_message as False
         self.repository.save(self.model_instance, send_message=False)
 
         # Assert the save method on the adapter was called
-        self.db_adapter_mock.save.assert_called_once()
+        self.db_adapter_mock.run_transaction.assert_called_once_with([("", ()), ("", ())])
 
         # Assert the send_message method was not called
         self.message_adapter_mock.send_message.assert_not_called()


### PR DESCRIPTION
# Describe your changes
- Use single transaction for inserting data in table and audit table

## Issue ticket number and link
ROC-38

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings

(if needed and available)