### PR TITLE
[ROC-39] Update VersionedModel to use UUID hex instead of UUID object

### DIFF
--- a/rococo/models/versioned_model.py
+++ b/rococo/models/versioned_model.py
@@ -23,7 +23,7 @@ def get_uuid_hex(_int=None):
     if _int is None:
         return uuid4().hex
     else:
-        return UUID(int=_int).hex
+        return UUID(int=_int, version=4).hex
 
 
 def import_models_module(current_module, module_name):

--- a/rococo/models/versioned_model.py
+++ b/rococo/models/versioned_model.py
@@ -19,6 +19,13 @@ def default_datetime():
     return datetime.utcnow()
 
 
+def get_uuid_hex(_int=None):
+    if _int is None:
+        return uuid4().hex
+    else:
+        return UUID(int=_int).hex
+
+
 def import_models_module(current_module, module_name):
     root_path = os.path.dirname(os.path.abspath(current_module.__file__))
 
@@ -35,11 +42,11 @@ def import_models_module(current_module, module_name):
 class VersionedModel:
     """A base class for versioned models with common (Big 6) attributes."""
 
-    entity_id: UUID = field(default_factory=uuid4, metadata={'field_type': 'entity_id'})
-    version: UUID = field(default_factory=lambda: UUID('00000000-0000-4000-8000-000000000000'), metadata={'field_type': 'uuid'})
+    entity_id: UUID = field(default_factory=get_uuid_hex, metadata={'field_type': 'entity_id'})
+    version: UUID = field(default_factory=lambda: get_uuid_hex(0), metadata={'field_type': 'uuid'})
     previous_version: UUID = field(default_factory=lambda: None, metadata={'field_type': 'uuid'})
     active: bool = True
-    changed_by_id: UUID = field(default_factory=lambda: UUID('00000000-0000-4000-8000-000000000000'), metadata={'field_type': 'uuid'})
+    changed_by_id: UUID = field(default_factory=lambda: get_uuid_hex(0), metadata={'field_type': 'uuid'})
     changed_on: datetime = field(default_factory=default_datetime)
 
     _is_partial: InitVar[bool] = False
@@ -174,7 +181,7 @@ class VersionedModel:
                 if v is not None and not isinstance(v, UUID):
                     try:
                         # Attempt to cast the string to a UUID
-                        filtered_data[k] = UUID(v)
+                        filtered_data[k] = UUID(v).hex
                     except ValueError:
                         # Handle the case where the string is not a valid UUID
                         print(f"'{v}' is not a valid UUID.")
@@ -192,7 +199,7 @@ class VersionedModel:
         if self.version:
             self.previous_version = self.version
         else:
-            self.previous_version = UUID('00000000-0000-4000-8000-000000000000')
+            self.previous_version = get_uuid_hex(0)
         self.version = uuid4()
         self.changed_on = datetime.utcnow()
         if changed_by_id is not None:

--- a/rococo/repositories/mysql/mysql_repository.py
+++ b/rococo/repositories/mysql/mysql_repository.py
@@ -76,7 +76,7 @@ class MySqlRepository(BaseRepository):
                         data[field.name] = _process_record(field_value, field_model_class)
                     elif isinstance(field_value, str):
                         if field.name == 'entity_id':
-                            data[field.name] = UUID(field_value)
+                            data[field.name] = UUID(field_value).hex
                         else:
                             field_data = {'entity_id': field_value}
                             for _field in fields(field_model_class):

--- a/rococo/repositories/surrealdb/surreal_db_repository.py
+++ b/rococo/repositories/surrealdb/surreal_db_repository.py
@@ -32,7 +32,7 @@ class SurrealDbRepository(BaseRepository):
         suffix = "⟩"
         if surreal_id.startswith(prefix) and surreal_id.endswith(suffix):
             uuid_str = surreal_id[len(prefix):-len(suffix)]
-            formatted_uuid = UUID(uuid_str)
+            formatted_uuid = UUID(uuid_str).hex
             return formatted_uuid
         else:
             raise ValueError(f"Invalid input format or no UUID found in the input string: {surreal_id}")

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='rococo',
-    version='1.0.11',
+    version='1.0.12',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/model_test.py
+++ b/tests/model_test.py
@@ -39,7 +39,7 @@ def test_from_dict():
     """
     Test converting model to dict
     """
-    model_dict = {"entity_id": UUID(int=0), "version": UUID(int=0)}
+    model_dict = {"entity_id": UUID(int=0).hex, "version": UUID(int=0).hex}
 
     dict_as_model = VersionedModel.from_dict(model_dict)
 
@@ -60,7 +60,7 @@ def test_sublass_from_dict():
         """TestModel for VersionedModel"""
         test_attribute: int = 0
 
-    model_dict = {"entity_id": UUID(int=0), "version": UUID(int=0), "test_attribute": 5}
+    model_dict = {"entity_id": UUID(int=0).hex, "version": UUID(int=0).hex, "test_attribute": 5}
     dict_as_model = TestModel.from_dict(model_dict)
 
     assert isinstance(dict_as_model, TestModel)
@@ -70,6 +70,6 @@ def test_sublass_from_dict():
     assert hasattr(dict_as_model, "changed_by_id")
     assert hasattr(dict_as_model, "changed_on")
 
-    assert dict_as_model.entity_id == UUID(int=0)
-    assert dict_as_model.version == UUID(int=0)
+    assert dict_as_model.entity_id == UUID(int=0).hex
+    assert dict_as_model.version == UUID(int=0).hex
     assert dict_as_model.test_attribute == 5

--- a/tests/surreal_db_repository_test.py
+++ b/tests/surreal_db_repository_test.py
@@ -28,7 +28,7 @@ class SurrealDbRepositoryTestCase(unittest.TestCase):
     def setUp(self):
         self.db_adapter_mock = MagicMock()
         self.message_adapter_mock = MagicMock()
-        self.model_data = {"entity_id": UUID(int=8), "name": "test"}
+        self.model_data = {"entity_id": UUID(int=8).hex, "name": "test"}
         self.model_instance = VersionedModelHelper(**self.model_data)
         self.queue_name = "test_queue"
         self.repository = SurrealDbRepository(


### PR DESCRIPTION
# Describe your changes
Update VersionedModel to use UUID hex instead of UUID object

## Issue ticket number and link
ROC-39

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings

(if needed and available)