### PR TITLE
Fix: add missing MongoDbRepository import

### DIFF
--- a/rococo/repositories/mongodb/__init__.py
+++ b/rococo/repositories/mongodb/__init__.py
@@ -1,0 +1,1 @@
+from .mongodb_repository import MongoDbRepository

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='rococo',
-    version='1.0.33',
+    version='1.0.34',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',


### PR DESCRIPTION
### Summary
Added the missing import for `MongoDbRepository` in `rococo/repositories/mongodb/__init__.py`. This ensures the repository class is properly exposed when importing the module.

### Why
Previously, importing from `rococo.repositories.mongodb` did not expose `MongoDbRepository`, which could lead to import errors when using this module.

@burilovmv Could you please review this PR? It's ready for review.