### PR TITLE
[ROC-73] Fix pagination in mongodb adapter

### DIFF
--- a/rococo/data/mongodb.py
+++ b/rococo/data/mongodb.py
@@ -191,13 +191,14 @@ class MongoDBAdapter(DbAdapter):
         conditions: Optional[Dict[str, Any]] = None,
         hint: Optional[str] = None,
         sort: Optional[List[Tuple[str, int]]] = None,
-        limit: int = 100,
+        limit: Optional[int] = None,
+        offset: Optional[int] = None,
     ) -> List[Dict[str, Any]]:
         """
         Retrieve multiple documents from the specified MongoDB collection based on given conditions.
 
         This method fetches multiple documents from the MongoDB collection specified by `table`.
-        Additional query parameters such as `hint`, `sort`, and `limit` can be provided to optimize the query
+        Additional query parameters such as `hint`, `sort`, `limit`, and `offset` can be provided to optimize the query
         and define the order of the returned documents.
 
         Args:
@@ -205,7 +206,8 @@ class MongoDBAdapter(DbAdapter):
             conditions (Optional[Dict[str, Any]]): An optional dictionary specifying the conditions to filter the documents.
             hint (Optional[str]): An optional index hint to optimize the query.
             sort (Optional[List[Tuple[str, int]]]): An optional list of tuples specifying the sort order.
-            limit (int): The maximum number of documents to return. Defaults to 100.
+            limit (Optional[int]): The maximum number of documents to return. If None, no limit is applied.
+            offset (Optional[int]): The number of documents to skip before returning results. If None, no offset is applied.
 
         Returns:
             List[Dict[str, Any]]: The list of documents that match the conditions.
@@ -219,7 +221,9 @@ class MongoDBAdapter(DbAdapter):
                                ({'hint': hint} if hint else {}))
             if sort:
                 cursor = cursor.sort(sort)
-            if limit > 0:
+            if offset is not None and offset > 0:
+                cursor = cursor.skip(offset)
+            if limit is not None and limit > 0:
                 cursor = cursor.limit(limit)
             return list(cursor)
         except errors.PyMongoError as e:

--- a/rococo/repositories/mongodb/mongodb_repository.py
+++ b/rococo/repositories/mongodb/mongodb_repository.py
@@ -109,7 +109,8 @@ class MongoDbRepository(BaseRepository):
         collection_name: str,
         index: str,
         query: Optional[Dict[str, Any]] = None,
-        limit: int = 0
+        limit: Optional[int] = None,
+        offset: Optional[int] = None
     ) -> List[VersionedModel]:
         """
         Retrieves a list of records from a specified MongoDB collection based on the given query parameters and index.
@@ -118,7 +119,8 @@ class MongoDbRepository(BaseRepository):
             collection_name (str): The name of the collection from which to fetch the records.
             index (str): The index to use for the query, providing a hint for optimization.
             query (Optional[Dict[str, Any]], optional): A dictionary of query parameters to filter the records. Defaults to None.
-            limit (int, optional): The maximum number of records to retrieve. If set to 0, the default limit of 100 is used. Defaults to 0.
+            limit (Optional[int], optional): The maximum number of records to retrieve. If None, no limit is applied. Defaults to None.
+            offset (Optional[int], optional): The number of records to skip before returning results. If None, no offset is applied. Defaults to None.
 
         Returns:
             List[VersionedModel]: A list of model instances, each representing a record from the collection.
@@ -127,14 +129,13 @@ class MongoDbRepository(BaseRepository):
         if query:
             db_conditions.update(query)
 
-        actual_limit = limit if limit > 0 else 100
-
         records_data = self._execute_within_context(
             lambda: self.adapter.get_many(
                 table=collection_name,
                 conditions=db_conditions,
                 hint=index,
-                limit=actual_limit
+                limit=limit,
+                offset=offset
             )
         )
 

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.0.39',
+    version='1.0.40',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/base_repository_test.py
+++ b/tests/base_repository_test.py
@@ -355,6 +355,7 @@ class TestBaseRepository:
             conditions,
             sort_order,
             limit,
+            0,     # offset
             fetch_related=fetch_related_list
         )
         repository._process_data_from_db.assert_called_once_with(db_response)
@@ -392,6 +393,7 @@ class TestBaseRepository:
             None,  # conditions
             None,  # sort
             100,   # limit
+            0,     # offset
             fetch_related=None
         )
         repository._process_data_from_db.assert_called_once_with(
@@ -420,6 +422,7 @@ class TestBaseRepository:
             None,  # conditions
             None,  # sort
             100,   # limit
+            0,     # offset
             fetch_related=None
         )
         repository._process_data_from_db.assert_called_once_with([])

--- a/tests/mongodb_repository_test.py
+++ b/tests/mongodb_repository_test.py
@@ -287,8 +287,8 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
             table="test_collection",
             conditions={'active': True},
             hint="entity_id_idx",
-            limit=0,    # default limit (0 means no limit)
-            offset=0    # default offset
+            limit=None,    # default limit (0 means no limit)
+            offset=None    # default offset
         )
 
         # Verify the result


### PR DESCRIPTION
# Describe your changes
* Added offset field to get_many() method both in BaseRepository and MongoDBRepository (for consistency)
* Removed ugly logic with hidden limit of 100 records if limit=0 is passed
* Allow passing None to both limit and offset
* Added unit tests

## Issue ticket number and link
[ROC-73](https://freelancedevelopercoach.atlassian.net/browse/ROC-73)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings

(if needed and available)