### PR TITLE
Mongo improvements (ROC-78/79/80), v1.1.1

### DIFF
--- a/rococo/repositories/base_repository.py
+++ b/rococo/repositories/base_repository.py
@@ -30,6 +30,12 @@ class BaseRepository:
         self.user_id = user_id
         # Don't save calculated fields (properties) to database by default
         self.save_calculated_fields = False
+        # Enable auditing by default
+        self.use_audit_table = True
+        # Ttl field for delete() method
+        self.ttl_field = None
+        # Ttl (in minutes) for deleted records
+        self.ttl_minutes = 0
 
     def _execute_within_context(
         self,

--- a/rococo/repositories/mongodb/mongodb_repository.py
+++ b/rococo/repositories/mongodb/mongodb_repository.py
@@ -171,7 +171,7 @@ class MongoDbRepository(BaseRepository):
         instance.active = False
 
         data = instance.as_dict(
-            convert_datetime_to_iso_string=True, convert_uuids=True)
+            convert_datetime_to_iso_string=True, convert_uuids=True, export_properties=self.save_calculated_fields)
 
         if instance.previous_version and instance.previous_version != get_uuid_hex(0):
             self._execute_within_context(

--- a/rococo/repositories/mongodb/mongodb_repository.py
+++ b/rococo/repositories/mongodb/mongodb_repository.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from uuid import UUID
-from typing import Any, Dict, List, Optional, Type
+from typing import Any, Dict, List, Optional, Type, Tuple
 from rococo.data import MongoDBAdapter
 from rococo.messaging import MessageAdapter
 from rococo.repositories import BaseRepository
@@ -111,6 +111,7 @@ class MongoDbRepository(BaseRepository):
         collection_name: str,
         index: str,
         query: Optional[Dict[str, Any]] = None,
+        sort: Optional[List[Tuple[str, int]]] = None,
         limit: Optional[int] = None,
         offset: Optional[int] = None
     ) -> List[VersionedModel]:
@@ -136,6 +137,7 @@ class MongoDbRepository(BaseRepository):
                 table=collection_name,
                 conditions=db_conditions,
                 hint=index,
+                sort=sort,
                 limit=limit,
                 offset=offset
             )

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.1.0',
+    version='1.1.1',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',


### PR DESCRIPTION
# Describe your changes
* Added support for field aliases
* Added "sort" field to get_many method for mongo repository
* Fixed bug in Mongo repository not using save_calculated_fields flag in delete() method
* Added support for TTL fields for Mongo repository
* Added "use_audit_table" flag to base and Mongo repositories

## Issue ticket number and link
[ROC-78](https://freelancedevelopercoach.atlassian.net/browse/ROC-78)
[ROC-79](https://freelancedevelopercoach.atlassian.net/browse/ROC-79)
[ROC-80](https://freelancedevelopercoach.atlassian.net/browse/ROC-80)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings

(if needed and available)