### PR TITLE
[ROC-82] v1.1.3 Fix automatic datetime conversion in MongoDB repository

### DIFF
--- a/rococo/models/versioned_model.py
+++ b/rococo/models/versioned_model.py
@@ -1,11 +1,15 @@
 import pkgutil
 import os
 import importlib
+import logging
 from uuid import uuid4, UUID
 from dataclasses import dataclass, field, fields, InitVar, is_dataclass
 from datetime import datetime, timezone
+from dateutil.parser import isoparse
 from typing import Any, Dict, List, Union, get_type_hints, get_origin, get_args
 from enum import Enum
+
+logger = logging.getLogger(__name__)
 
 # Constants for VersionedModel field groups
 BIG_6_FIELDS = {'entity_id', 'version', 'previous_version',
@@ -148,7 +152,8 @@ class VersionedModel:
                                      for u in value[1:-1].split(',') if u.strip()]
                         setattr(self, f.name, uuid_list)
                     except ValueError:
-                        print(f"Invalid UUIDs in list for field '{f.name}'")
+                        logger.info(
+                            f"Invalid UUIDs in list for field '{f.name}'")
 
     def __getattribute__(self, name):
         """
@@ -464,9 +469,9 @@ class VersionedModel:
                     clean_data[k] = UUID(
                         v).hex if v and not isinstance(v, UUID) else v
                 except ValueError:
-                    print(f"'{v}' is not a valid UUID.")
+                    logger.info(f"'{v}' is not a valid UUID.")
 
-            # Handle enum conversion from string values
+            # Handle enum conversion from string values and datetime conversion from ISO strings
             elif v is not None:
                 expected_type = hints.get(k)
                 if expected_type:
@@ -483,12 +488,28 @@ class VersionedModel:
                             except ValueError:
                                 # If the string value doesn't match any enum value, leave as is
                                 pass
+                        # Find datetime type in the Union for Optional[datetime]
+                        datetime_type = next(
+                            (arg for arg in args if arg is datetime), None)
+                        if datetime_type and isinstance(v, str):
+                            try:
+                                clean_data[k] = isoparse(v)
+                            except (ValueError, TypeError):
+                                # If the string value can't be parsed as datetime, leave as is
+                                pass
                     # Handle direct enum types
                     elif isinstance(expected_type, type) and issubclass(expected_type, Enum) and isinstance(v, str):
                         try:
                             clean_data[k] = expected_type(v)
                         except ValueError:
                             # If the string value doesn't match any enum value, leave as is
+                            pass
+                    # Handle direct datetime types
+                    elif expected_type is datetime and isinstance(v, str):
+                        try:
+                            clean_data[k] = isoparse(v)
+                        except (ValueError, TypeError):
+                            # If the string value can't be parsed as datetime, leave as is
                             pass
 
                 # Handle dataclass conversion from dict values

--- a/rococo/repositories/mongodb/mongodb_repository.py
+++ b/rococo/repositories/mongodb/mongodb_repository.py
@@ -64,7 +64,7 @@ class MongoDbRepository(BaseRepository):
         """
         instance.prepare_for_save(changed_by_id=self.user_id)
         data = instance.as_dict(
-            convert_datetime_to_iso_string=True,
+            convert_datetime_to_iso_string=False,
             convert_uuids=True,
             export_properties=self.save_calculated_fields
         )

--- a/rococo/repositories/surrealdb/person_organization_role_repository.py
+++ b/rococo/repositories/surrealdb/person_organization_role_repository.py
@@ -1,12 +1,16 @@
 import copy
+import logging
 from typing import List, Union
 from rococo.repositories.surrealdb import SurrealDbRepository
 from rococo.models.surrealdb import PersonOrganizationRole
 
+logger = logging.getLogger(__name__)
+
 
 class PersonOrganizationRoleRepository(SurrealDbRepository):
     def __init__(self, adapter, message_adapter, message_queue_name):
-        super().__init__(adapter, PersonOrganizationRole, message_adapter, message_queue_name)
+        super().__init__(adapter, PersonOrganizationRole,
+                         message_adapter, message_queue_name)
 
     def find_organizations_by_member(self, member_id: str, get_member: bool = False) -> List[PersonOrganizationRole]:
         """finds all the organizations that a Person identified by member_id is a member of 
@@ -19,9 +23,10 @@ class PersonOrganizationRoleRepository(SurrealDbRepository):
             List[PersonOrganizationRole]: found PersonOrganizationRole
         """
         conditions = {"person": member_id}
-        fetch_related: List[str] = ["organization", "person"] if get_member else ["organization"]
+        fetch_related: List[str] = ["organization",
+                                    "person"] if get_member else ["organization"]
         return self.get_many(conditions, fetch_related=fetch_related)
-    
+
     def find_organizations_by_owner(self, owner_id: str, get_owner: bool = False) -> List[PersonOrganizationRole]:
         """finds all the organizations that a Person identified by member_id is an owner of 
 
@@ -32,8 +37,10 @@ class PersonOrganizationRoleRepository(SurrealDbRepository):
         Returns:
             List[PersonOrganizationRole]: found PersonOrganizationRole-s
         """
-        print(f"[find_organizations_by_owner] owner_id: {owner_id}", flush=True)
+        logger.info(
+            f"[find_organizations_by_owner] owner_id: {owner_id}")
         OWNER: str = "OWNER"
         conditions = {"person": owner_id, "role": OWNER}
-        fetch_related: List[str] = ["organization", "person"] if get_owner else ["organization"]
+        fetch_related: List[str] = ["organization",
+                                    "person"] if get_owner else ["organization"]
         return self.get_many(conditions, fetch_related=fetch_related)

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.1.2',
+    version='1.1.3',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/mongodb_repository_test.py
+++ b/tests/mongodb_repository_test.py
@@ -3,12 +3,17 @@ Extended MongoDbRepository test cases
 """
 
 import json
+import uuid
 import unittest
 from datetime import datetime, timezone, timedelta
-from uuid import UUID
 from unittest.mock import MagicMock
-from .base_repository_test import TestVersionedModel
 from rococo.repositories.mongodb.mongodb_repository import MongoDbRepository
+from rococo.models import VersionedModel
+
+
+class TestVersionedModel(VersionedModel):
+    def __post_init__(self, _is_partial):
+        return super().__post_init__(_is_partial)
 
 
 class MongoDbRepositoryTestCase(unittest.TestCase):
@@ -22,7 +27,7 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         self.db_adapter_mock = MagicMock()
         self.message_adapter_mock = MagicMock()
         self.queue_name = "test_queue"
-        self.model_data = {"entity_id": UUID(int=8)}
+        self.model_data = {"entity_id": uuid.uuid4().hex}
         self.model_instance = TestVersionedModel(**self.model_data)
 
         self.repository = MongoDbRepository(
@@ -130,13 +135,13 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         """
         self.repository._execute_within_context = MagicMock()
         instances = [TestVersionedModel(
-            entity_id=UUID(int=i)) for i in range(3)]
+            entity_id=uuid.uuid4().hex) for i in range(3)]
 
         # stub insert_many to return a list of dummy docs
         self.db_adapter_mock.insert_many.return_value = [
-            {'entity_id': str(instances[0].entity_id), 'active': True},
-            {'entity_id': str(instances[1].entity_id), 'active': True},
-            {'entity_id': str(instances[2].entity_id), 'active': True},
+            {'entity_id': instances[0].entity_id, 'active': True},
+            {'entity_id': instances[1].entity_id, 'active': True},
+            {'entity_id': instances[2].entity_id, 'active': True},
         ]
 
         self.repository.create_many(
@@ -179,13 +184,13 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         """
         # The adapter should return data that can be converted back to a model
         # Using a more complete representation based on TestVersionedModel.as_dict()
-        mock_return_data = self.model_instance.as_dict()
+        mock_return_data = self.model_instance.as_dict(convert_uuids=True)
         self.db_adapter_mock.get_one.return_value = mock_return_data
 
         result = self.repository.get_one("test_collection", "entity_id_idx", {
-                                         "entity_id": str(self.model_instance.entity_id)})
+                                         "entity_id": self.model_instance.entity_id})
         self.assertIsInstance(result, TestVersionedModel)
-        self.assertEqual(result.entity_id, self.model_instance.entity_id)
+        self.assertEqual(result.entity_id, mock_return_data["entity_id"])
 
     def test_get_one_returns_none(self):
         """
@@ -212,8 +217,10 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         The method should return a list of instances of the model with the correct entity_id.
         """
         # Provide more complete data for each instance
-        instance1_data = TestVersionedModel(entity_id=UUID(int=1)).as_dict()
-        instance2_data = TestVersionedModel(entity_id=UUID(int=2)).as_dict()
+        instance1_data = TestVersionedModel(
+            entity_id=uuid.uuid4().hex).as_dict()
+        instance2_data = TestVersionedModel(
+            entity_id=uuid.uuid4().hex).as_dict()
 
         self.db_adapter_mock.get_many.return_value = [
             instance1_data, instance2_data]
@@ -244,8 +251,10 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         pagination functionality works as expected.
         """
         # Provide test data
-        instance1_data = TestVersionedModel(entity_id=UUID(int=1)).as_dict()
-        instance2_data = TestVersionedModel(entity_id=UUID(int=2)).as_dict()
+        instance1_data = TestVersionedModel(
+            entity_id=uuid.uuid4().hex).as_dict()
+        instance2_data = TestVersionedModel(
+            entity_id=uuid.uuid4().hex).as_dict()
 
         self.db_adapter_mock.get_many.return_value = [
             instance1_data, instance2_data]
@@ -277,7 +286,8 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         when the offset parameter is not provided, maintaining backward compatibility.
         """
         # Provide test data
-        instance1_data = TestVersionedModel(entity_id=UUID(int=1)).as_dict()
+        instance1_data = TestVersionedModel(
+            entity_id=uuid.uuid4().hex).as_dict()
 
         self.db_adapter_mock.get_many.return_value = [instance1_data]
 
@@ -310,7 +320,7 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         self.repository.ttl_minutes = 30
 
         # Create a test instance
-        test_instance = TestVersionedModel(entity_id=UUID(int=123))
+        test_instance = TestVersionedModel(entity_id=uuid.uuid4().hex)
         test_instance.active = True
 
         # Mock the adapter methods
@@ -377,7 +387,7 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         self.repository.ttl_minutes = 30  # This should be ignored when ttl_field is None
 
         # Create a test instance
-        test_instance = TestVersionedModel(entity_id=UUID(int=456))
+        test_instance = TestVersionedModel(entity_id=uuid.uuid4().hex)
         test_instance.active = True
 
         # Mock the adapter methods
@@ -436,7 +446,7 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         self.repository.ttl_minutes = 60  # 1 hour
 
         # Create a test instance
-        test_instance = TestVersionedModel(entity_id=UUID(int=789))
+        test_instance = TestVersionedModel(entity_id=uuid.uuid4().hex)
         test_instance.active = True
 
         # Mock the adapter methods
@@ -480,6 +490,419 @@ class MongoDbRepositoryTestCase(unittest.TestCase):
         self.assertLess(time_difference, 60,
                         f"TTL timestamp should be approximately 60 minutes from delete time. "
                         f"Expected: {expected_ttl_time}, Actual: {actual_ttl_time}")
+
+    def test_datetime_parsing_in_get_one(self):
+        """
+        Test that datetime fields stored as ISO strings in MongoDB are correctly parsed back to datetime objects.
+
+        This test simulates the scenario where datetime fields were incorrectly saved as strings
+        in MongoDB and verifies that the from_dict method correctly parses them back to datetime objects.
+        """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class TestModelWithDatetime(TestVersionedModel):
+            created_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+            updated_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+
+        # Create repository with the datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithDatetime,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Mock data with datetime fields as ISO strings (simulating MongoDB storage issue)
+        mock_data_with_datetime_strings = {
+            'entity_id': uuid.uuid4().hex,
+            'version': uuid.uuid4().hex,
+            'previous_version': None,
+            'active': True,
+            'changed_by_id': uuid.uuid4().hex,
+            'changed_on': '2024-01-15T10:30:00+00:00',  # ISO string
+            'created_at': '2024-01-15T09:00:00+00:00',   # ISO string
+            'updated_at': '2024-01-15T11:00:00+00:00',   # ISO string
+        }
+
+        # Mock the adapter to return data with datetime strings
+        self.db_adapter_mock.get_one.return_value = mock_data_with_datetime_strings
+
+        # Call get_one
+        result = datetime_repository.get_one(
+            "test_collection", "entity_id_idx", {"entity_id": mock_data_with_datetime_strings["entity_id"]})
+
+        # Verify that the result is an instance of the model
+        self.assertIsInstance(result, TestModelWithDatetime)
+
+        # Verify that datetime strings were parsed back to datetime objects
+        self.assertIsInstance(result.changed_on, datetime)
+        self.assertIsInstance(result.created_at, datetime)
+        self.assertIsInstance(result.updated_at, datetime)
+
+        # Verify the actual datetime values
+        expected_changed_on = datetime(
+            2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        expected_created_at = datetime(
+            2024, 1, 15, 9, 0, 0, tzinfo=timezone.utc)
+        expected_updated_at = datetime(
+            2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc)
+
+        self.assertEqual(result.changed_on, expected_changed_on)
+        self.assertEqual(result.created_at, expected_created_at)
+        self.assertEqual(result.updated_at, expected_updated_at)
+
+    def test_datetime_parsing_in_get_many(self):
+        """
+        Test that datetime fields stored as ISO strings are correctly parsed in get_many results.
+        """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class TestModelWithDatetime(TestVersionedModel):
+            created_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+
+        # Create repository with the datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithDatetime,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Mock data with multiple records containing datetime strings
+        mock_data_list = [
+            {
+                'entity_id': uuid.uuid4().hex,
+                'version': uuid.uuid4().hex,
+                'active': True,
+                'changed_by_id': uuid.uuid4().hex,
+                'changed_on': '2024-01-15T10:00:00+00:00',
+                'created_at': '2024-01-15T09:00:00+00:00',
+            },
+            {
+                'entity_id': uuid.uuid4().hex,
+                'version': uuid.uuid4().hex,
+                'active': True,
+                'changed_by_id': uuid.uuid4().hex,
+                'changed_on': '2024-01-15T11:00:00+00:00',
+                'created_at': '2024-01-15T10:00:00+00:00',
+            }
+        ]
+
+        # Mock the adapter to return data with datetime strings
+        self.db_adapter_mock.get_many.return_value = mock_data_list
+
+        # Call get_many
+        results = datetime_repository.get_many(
+            "test_collection", "entity_id_idx")
+
+        # Verify that we got the expected number of results
+        self.assertEqual(len(results), 2)
+
+        # Verify that all results are instances of the model
+        for result in results:
+            self.assertIsInstance(result, TestModelWithDatetime)
+
+            # Verify that datetime strings were parsed back to datetime objects
+            self.assertIsInstance(result.changed_on, datetime)
+            self.assertIsInstance(result.created_at, datetime)
+
+    def test_datetime_parsing_with_optional_fields(self):
+        """
+        Test datetime parsing works correctly with Optional[datetime] fields.
+        """
+        from dataclasses import dataclass, field
+        from typing import Optional
+
+        @dataclass
+        class TestModelWithOptionalDatetime(TestVersionedModel):
+            created_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+            updated_at: Optional[datetime] = None
+            deleted_at: Optional[datetime] = None
+
+        # Create repository with the optional datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithOptionalDatetime,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Mock data with some optional datetime fields as strings and some as None
+        mock_data = {
+            'entity_id': uuid.uuid4().hex,
+            'version': uuid.uuid4().hex,
+            'active': True,
+            'changed_by_id': uuid.uuid4().hex,
+            'changed_on': '2024-01-15T10:30:00+00:00',
+            'created_at': '2024-01-15T09:00:00+00:00',   # Required field as string
+            'updated_at': '2024-01-15T11:00:00+00:00',   # Optional field as string
+            'deleted_at': None                            # Optional field as None
+        }
+
+        # Mock the adapter to return data
+        self.db_adapter_mock.get_one.return_value = mock_data
+
+        # Call get_one
+        result = datetime_repository.get_one(
+            "test_collection", "entity_id_idx", {"entity_id": uuid.uuid4().hex})
+
+        # Verify that the result is an instance of the model
+        self.assertIsInstance(result, TestModelWithOptionalDatetime)
+
+        # Verify required datetime field was parsed
+        self.assertIsInstance(result.created_at, datetime)
+        self.assertEqual(result.created_at, datetime(
+            2024, 1, 15, 9, 0, 0, tzinfo=timezone.utc))
+
+        # Verify optional datetime field with string was parsed
+        self.assertIsInstance(result.updated_at, datetime)
+        self.assertEqual(result.updated_at, datetime(
+            2024, 1, 15, 11, 0, 0, tzinfo=timezone.utc))
+
+        # Verify optional datetime field with None remained None
+        self.assertIsNone(result.deleted_at)
+
+    def test_datetime_parsing_preserves_existing_datetime_objects(self):
+        """
+        Test that existing datetime objects are preserved and not converted to strings.
+        """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class TestModelWithDatetime(TestVersionedModel):
+            created_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+
+        # Create repository with the datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithDatetime,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Mock data with datetime objects (not strings)
+        existing_datetime = datetime(2024, 1, 15, 9, 0, 0, tzinfo=timezone.utc)
+        mock_data = {
+            'entity_id': uuid.uuid4().hex,
+            'version': uuid.uuid4().hex,
+            'active': True,
+            'changed_by_id': uuid.uuid4().hex,
+            'changed_on': existing_datetime,  # Already a datetime object
+            'created_at': existing_datetime,  # Already a datetime object
+        }
+
+        # Mock the adapter to return data
+        self.db_adapter_mock.get_one.return_value = mock_data
+
+        # Call get_one
+        result = datetime_repository.get_one(
+            "test_collection", "entity_id_idx", {"entity_id": uuid.uuid4().hex})
+
+        # Verify that the result is an instance of the model
+        self.assertIsInstance(result, TestModelWithDatetime)
+
+        # Verify that datetime objects were preserved
+        self.assertIsInstance(result.changed_on, datetime)
+        self.assertIsInstance(result.created_at, datetime)
+        self.assertEqual(result.changed_on, existing_datetime)
+        self.assertEqual(result.created_at, existing_datetime)
+
+    def test_datetime_parsing_handles_invalid_strings(self):
+        """
+        Test that invalid datetime strings are left unchanged and don't cause errors.
+        """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class TestModelWithDatetime(TestVersionedModel):
+            created_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+
+        # Create repository with the datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithDatetime,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Mock data with invalid datetime string
+        mock_data = {
+            'entity_id': uuid.uuid4().hex,
+            'version': uuid.uuid4().hex,
+            'active': True,
+            'changed_by_id': uuid.uuid4().hex,
+            'changed_on': '2024-01-15T10:30:00+00:00',  # Valid ISO string
+            'created_at': 'invalid-date-string',         # Invalid datetime string
+        }
+
+        # Mock the adapter to return data
+        self.db_adapter_mock.get_one.return_value = mock_data
+
+        # Call get_one - should not raise an exception
+        result = datetime_repository.get_one(
+            "test_collection", "entity_id_idx", {"entity_id": mock_data["entity_id"]})
+
+        # Verify that the result is an instance of the model
+        self.assertIsInstance(result, TestModelWithDatetime)
+
+        # Verify that valid datetime string was parsed
+        self.assertIsInstance(result.changed_on, datetime)
+        self.assertEqual(result.changed_on, datetime(
+            2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc))
+
+        # Verify that invalid datetime string was left as-is
+        self.assertEqual(result.created_at, 'invalid-date-string')
+        self.assertIsInstance(result.created_at, str)
+
+    def test_datetime_parsing_with_various_iso_formats(self):
+        """
+        Test that various ISO datetime formats are correctly parsed.
+        """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class TestModelWithMultipleDatetimes(TestVersionedModel):
+            datetime1: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+            datetime2: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+            datetime3: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+            datetime4: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+
+        # Create repository with the datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithMultipleDatetimes,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Mock data with various ISO format strings
+        mock_data = {
+            'entity_id': uuid.uuid4().hex,
+            'version': uuid.uuid4().hex,
+            'active': True,
+            'changed_by_id': uuid.uuid4().hex,
+            'changed_on': '2024-01-15T10:30:00+00:00',
+            'datetime1': '2024-01-15T10:30:00Z',           # UTC with Z
+            'datetime2': '2024-01-15T10:30:00+00:00',      # UTC with +00:00
+            'datetime3': '2024-01-15T10:30:00.123456Z',    # With microseconds
+            'datetime4': '2024-01-15T10:30:00-05:00',      # With timezone offset
+        }
+
+        # Mock the adapter to return data
+        self.db_adapter_mock.get_one.return_value = mock_data
+
+        # Call get_one
+        result = datetime_repository.get_one(
+            "test_collection", "entity_id_idx", {"entity_id": mock_data["entity_id"]})
+
+        # Verify that the result is an instance of the model
+        self.assertIsInstance(result, TestModelWithMultipleDatetimes)
+
+        # Verify that all datetime formats were parsed correctly
+        self.assertIsInstance(result.datetime1, datetime)
+        self.assertIsInstance(result.datetime2, datetime)
+        self.assertIsInstance(result.datetime3, datetime)
+        self.assertIsInstance(result.datetime4, datetime)
+
+        # Verify specific values for UTC formats
+        expected_utc_time = datetime(
+            2024, 1, 15, 10, 30, 0, tzinfo=timezone.utc)
+        self.assertEqual(result.datetime1, expected_utc_time)
+        self.assertEqual(result.datetime2, expected_utc_time)
+
+        # Verify microseconds are preserved
+        self.assertEqual(result.datetime3.microsecond, 123456)
+
+    def test_datetime_parsing_integration_with_save_and_load(self):
+        """
+        Test datetime parsing works in a complete save/load cycle.
+
+        This test verifies that datetime objects can be saved (potentially as strings)
+        and then loaded back correctly as datetime objects.
+        """
+        from dataclasses import dataclass, field
+
+        @dataclass
+        class TestModelWithDatetime(TestVersionedModel):
+            created_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+            updated_at: datetime = field(
+                default_factory=lambda: datetime.now(timezone.utc))
+
+        # Create repository with the datetime model
+        datetime_repository = MongoDbRepository(
+            db_adapter=self.db_adapter_mock,
+            model=TestModelWithDatetime,
+            message_adapter=self.message_adapter_mock,
+            queue_name=self.queue_name
+        )
+
+        # Create a model instance with datetime objects
+        original_created = datetime(2024, 1, 15, 9, 0, 0, tzinfo=timezone.utc)
+        original_updated = datetime(
+            2024, 1, 15, 11, 30, 45, tzinfo=timezone.utc)
+
+        test_instance = TestModelWithDatetime(
+            entity_id=uuid.uuid4().hex,
+            created_at=original_created,
+            updated_at=original_updated
+        )
+
+        # Mock the save operation - simulate that datetime objects might be converted to strings
+        def mock_save(collection_name, data):
+            # Simulate the scenario where datetime objects are converted to ISO strings during save
+            saved_data = data.copy()
+            if isinstance(saved_data.get('created_at'), datetime):
+                saved_data['created_at'] = saved_data['created_at'].isoformat()
+            if isinstance(saved_data.get('updated_at'), datetime):
+                saved_data['updated_at'] = saved_data['updated_at'].isoformat()
+            return saved_data
+
+        self.db_adapter_mock.save.side_effect = mock_save
+        self.db_adapter_mock.move_entity_to_audit_table.return_value = None
+
+        # Save the instance
+        saved_instance = datetime_repository.save(
+            test_instance, "test_collection")
+
+        # Now simulate loading the data back - the adapter returns data with datetime strings
+        mock_loaded_data = {
+            'entity_id': uuid.uuid4().hex,
+            'version': saved_instance.version,
+            'active': True,
+            'changed_by_id': saved_instance.changed_by_id,
+            'changed_on': saved_instance.changed_on.isoformat(),  # As ISO string
+            'created_at': original_created.isoformat(),           # As ISO string
+            'updated_at': original_updated.isoformat(),           # As ISO string
+        }
+
+        self.db_adapter_mock.get_one.return_value = mock_loaded_data
+
+        # Load the instance back
+        loaded_instance = datetime_repository.get_one(
+            "test_collection", "entity_id_idx", {"entity_id": mock_loaded_data["entity_id"]})
+
+        # Verify that the loaded instance has datetime objects, not strings
+        self.assertIsInstance(loaded_instance, TestModelWithDatetime)
+        self.assertIsInstance(loaded_instance.created_at, datetime)
+        self.assertIsInstance(loaded_instance.updated_at, datetime)
+        self.assertIsInstance(loaded_instance.changed_on, datetime)
+
+        # Verify that the datetime values are correct
+        self.assertEqual(loaded_instance.created_at, original_created)
+        self.assertEqual(loaded_instance.updated_at, original_updated)
 
 
 if __name__ == '__main__':

--- a/tests/test_calculated_properties_fix.py
+++ b/tests/test_calculated_properties_fix.py
@@ -1,0 +1,143 @@
+"""
+Test cases for calculated properties fix in VersionedModel
+"""
+
+import unittest
+from dataclasses import dataclass
+from rococo.models.versioned_model import VersionedModel
+
+
+@dataclass
+class TestModelWithCalculatedProperty(VersionedModel):
+    """Test model with a calculated property similar to OrganizationImport.error_count"""
+
+    count: int = 0
+    errors: list = None
+
+    def __post_init__(self, _is_partial):
+        if self.errors is None:
+            self.errors = []
+        super().__post_init__(_is_partial)
+
+    @property
+    def error_count(self) -> int:
+        """Calculate error count - this is a read-only property without setter"""
+        return len(self.errors) if self.errors else 0
+
+
+class CalculatedPropertiesFixTestCase(unittest.TestCase):
+
+    def test_setattr_skips_calculated_properties(self):
+        """Test that __setattr__ skips calculated properties (properties without setters)"""
+        instance = TestModelWithCalculatedProperty(
+            count=5, errors=['error1', 'error2'])
+
+        # Verify the calculated property works
+        self.assertEqual(instance.error_count, 2)
+
+        # Try to set the calculated property - this should be silently ignored
+        setattr(instance, 'error_count', 999)
+
+        # The calculated property should still return the calculated value
+        self.assertEqual(instance.error_count, 2)
+
+        # Regular fields should still be settable
+        setattr(instance, 'count', 10)
+        self.assertEqual(instance.count, 10)
+
+    def test_from_dict_skips_calculated_properties_in_extra_data(self):
+        """Test that from_dict skips calculated properties when processing extra data"""
+        # Simulate data that includes a calculated property (like from database)
+        data = {
+            'entity_id': 'test-entity-id',
+            'count': 5,
+            'errors': ['error1', 'error2'],
+            'error_count': 999,  # This should be ignored as it's a calculated property
+            'some_extra_field': 'extra_value'  # This should be kept
+        }
+
+        # Enable extra fields for this test
+        TestModelWithCalculatedProperty.allow_extra = True
+
+        try:
+            instance = TestModelWithCalculatedProperty.from_dict(data)
+
+            # The calculated property should return the calculated value, not the value from data
+            # len(['error1', 'error2'])
+            self.assertEqual(instance.error_count, 2)
+
+            # Regular fields should be set correctly
+            self.assertEqual(instance.count, 5)
+            self.assertEqual(instance.errors, ['error1', 'error2'])
+
+            # Extra fields should be preserved (except calculated properties)
+            self.assertEqual(instance.extra.get(
+                'some_extra_field'), 'extra_value')
+            self.assertNotIn('error_count', instance.extra)
+
+        finally:
+            # Clean up
+            TestModelWithCalculatedProperty.allow_extra = False
+
+    def test_as_dict_exports_calculated_properties_when_requested(self):
+        """Test that as_dict can export calculated properties when export_properties=True"""
+        instance = TestModelWithCalculatedProperty(
+            count=5, errors=['error1', 'error2'])
+
+        # With export_properties=True (default), calculated properties should be included
+        result = instance.as_dict(export_properties=True)
+        self.assertEqual(result['error_count'], 2)
+
+        # With export_properties=False, calculated properties should not be included
+        result = instance.as_dict(export_properties=False)
+        self.assertNotIn('error_count', result)
+
+    def test_mongodb_repository_scenario(self):
+        """Test the specific scenario that was failing in MongoDB repository"""
+        instance = TestModelWithCalculatedProperty(
+            count=5, errors=['error1', 'error2'])
+
+        # Simulate what happens in MongoDB repository:
+        # 1. as_dict() is called with export_properties=True (when save_calculated_fields=True)
+        data = instance.as_dict(export_properties=True)
+        self.assertEqual(data['error_count'], 2)
+
+        # 2. Data comes back from database and repository tries to set all fields
+        # This simulates the problematic code in mongodb_repository.py:
+        # for k, v in saved.items():
+        #     if hasattr(instance, k):
+        #         setattr(instance, k, v)
+
+        for k, v in data.items():
+            if hasattr(instance, k):
+                # This should not raise an AttributeError for calculated properties
+                setattr(instance, k, v)
+
+        # The calculated property should still work correctly
+        self.assertEqual(instance.error_count, 2)
+
+    def test_property_with_setter_is_not_skipped(self):
+        """Test that properties with setters are not skipped"""
+
+        @dataclass
+        class TestModelWithSettableProperty(VersionedModel):
+            _internal_value: int = 0
+
+            @property
+            def settable_property(self) -> int:
+                return self._internal_value
+
+            @settable_property.setter
+            def settable_property(self, value: int):
+                self._internal_value = value
+
+        instance = TestModelWithSettableProperty()
+
+        # This should work because the property has a setter
+        setattr(instance, 'settable_property', 42)
+        self.assertEqual(instance.settable_property, 42)
+        self.assertEqual(instance._internal_value, 42)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
# Describe your changes
* Fixed MongoDB repository - do not automatically convert datetimes to strings on save
* FIxed VersionedModel - do not try to recover calculated properties in __setattr__ or from_dict
* Adjusted unit tests

## Issue ticket number and link
[ROC-82](https://freelancedevelopercoach.atlassian.net/browse/ROC-82)
[ROC-75](https://freelancedevelopercoach.atlassian.net/browse/ROC-75)

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings

(if needed and available)