### PR TITLE
[WIP] feat(dynamodb): strict ACID transactions for versioned saves

### DIFF
--- a/docs/dynamo_db_usage.md
+++ b/docs/dynamo_db_usage.md
@@ -7,6 +7,7 @@ This guide explains how to use the DynamoDB adapter in Rococo. The adapter uses 
 *   **Zero Config**: No need to define PynamoDB models manually.
 *   **Dynamic Generation**: Automatically converts your Rococo models to PynamoDB models at runtime.
 *   **Audit Support**: Automatically handles audit tables for versioning.
+*   **Atomic Writes**: For `VersionedModel`s, updates are written using a DynamoDB transaction so the audit write and the new version write succeed or fail together.
 
 ## Installation
 
@@ -108,6 +109,14 @@ If you update a record, the adapter automatically moves the old version to an au
 *   **Range Key**: `version`
 
 Ensure your DynamoDB tables are created with these key schemas if you are provisioning them manually.
+
+### Atomic Save + Audit (ACID)
+When saving a `VersionedModel`, Rococo groups the audit insert and the main table write into a single DynamoDB `TransactWriteItems` operation.
+
+This means:
+- Either both the audit record and the new version are written, or neither is.
+- Updates use an optimistic-lock condition based on `previous_version`.
+- Creates use a "must not already exist" condition on `entity_id`.
 
 ## Example Application
 

--- a/docs/dynamo_db_usage.md
+++ b/docs/dynamo_db_usage.md
@@ -117,15 +117,17 @@ This means:
 - Either both the audit record and the new version are written, or neither is.
 - Updates use an optimistic-lock condition based on `previous_version`.
 - Creates use a "must not already exist" condition on `entity_id`.
+- Transactions are validated before execution against DynamoDB's 100-item limit.
 
 The audit snapshot is read with a strongly consistent `GetItem` during
 transaction execution, then the main-table write condition verifies that the
 source row is still at the expected `previous_version` when DynamoDB commits
 the `TransactWriteItems` request. DynamoDB does not support reading an item and
-writing a derived audit copy in a single transaction action, so this
-previous-version condition is the ACID guard: if another writer updates the row
-between the audit read and the commit, the whole transaction is rejected and no
-audit row is written.
+writing a derived audit copy in a single transaction action. For repository
+saves, the main-table write condition is the ACID guard; for audit-only
+transaction operations, Rococo adds a source-row `ConditionCheck`. If another
+writer updates the row between the audit read and the commit, the whole
+transaction is rejected and no audit row is written.
 
 After a versioned transaction succeeds, the repository performs a strongly
 consistent read of the saved item and hydrates the model from the committed

--- a/docs/dynamo_db_usage.md
+++ b/docs/dynamo_db_usage.md
@@ -118,6 +118,21 @@ This means:
 - Updates use an optimistic-lock condition based on `previous_version`.
 - Creates use a "must not already exist" condition on `entity_id`.
 
+The audit snapshot is read with a strongly consistent `GetItem` during
+transaction execution, then the main-table write condition verifies that the
+source row is still at the expected `previous_version` when DynamoDB commits
+the `TransactWriteItems` request. DynamoDB does not support reading an item and
+writing a derived audit copy in a single transaction action, so this
+previous-version condition is the ACID guard: if another writer updates the row
+between the audit read and the commit, the whole transaction is rejected and no
+audit row is written.
+
+After a versioned transaction succeeds, the repository performs a strongly
+consistent read of the saved item and hydrates the model from the committed
+DynamoDB state. Transaction failures are exception-based; callers should handle
+`TransactWriteError` or the wrapped runtime error instead of expecting a `None`
+failure sentinel.
+
 ## Example Application
 
 Here is a complete example of a simple Book Library Tracker using Rococo and DynamoDB.

--- a/rococo/data/__init__.py
+++ b/rococo/data/__init__.py
@@ -4,29 +4,41 @@ from .base import DbAdapter
 import logging
 
 logger = logging.getLogger(__name__)
+__all__ = ["DbAdapter"]
 
 
 # Conditional imports - only import if dependencies are available
 try:
     from .mongodb import MongoDBAdapter
+    __all__.append("MongoDBAdapter")
 except ImportError:
     logger.info("MongoDBAdapter not loaded - probably, missing dependencies")
     pass
 
 try:
     from .mysql import MySqlAdapter
+    __all__.append("MySqlAdapter")
 except ImportError:
     logger.info("MySqlAdapter not loaded - probably, missing dependencies")
     pass
 
 try:
     from .postgresql import PostgreSQLAdapter
+    __all__.append("PostgreSQLAdapter")
 except ImportError:
     logger.info("PostgreSQLAdapter not loaded - probably, missing dependencies")
     pass
 
 try:
+    from .dynamodb import DynamoDbAdapter, DynamoOperation
+    __all__.extend(["DynamoDbAdapter", "DynamoOperation"])
+except ImportError:
+    logger.info("DynamoDbAdapter not loaded - probably, missing dependencies")
+    pass
+
+try:
     from .surrealdb import SurrealDbAdapter
+    __all__.append("SurrealDbAdapter")
 except ImportError:
     logger.info("SurrealDbAdapter not loaded - probably, missing dependencies")
     pass

--- a/rococo/data/__init__.py
+++ b/rococo/data/__init__.py
@@ -30,8 +30,8 @@ except ImportError:
     pass
 
 try:
-    from .dynamodb import DynamoDbAdapter, DynamoOperation
-    __all__.extend(["DynamoDbAdapter", "DynamoOperation"])
+    from .dynamodb import DynamoDbAdapter, DynamoOperation, DynamoPostCommitVersionMismatch
+    __all__.extend(["DynamoDbAdapter", "DynamoOperation", "DynamoPostCommitVersionMismatch"])
 except ImportError:
     logger.info("DynamoDbAdapter not loaded - probably, missing dependencies")
     pass

--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -1,27 +1,42 @@
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
+import hashlib
 import os
 from pynamodb.models import Model
 from pynamodb.connection import Connection
 from pynamodb.transactions import TransactWrite
-from pynamodb.attributes import Attribute, UnicodeAttribute, BooleanAttribute, NumberAttribute, JSONAttribute, UTCDateTimeAttribute, ListAttribute
+from pynamodb.attributes import Attribute, UnicodeAttribute, BooleanAttribute, NumberAttribute, JSONAttribute, ListAttribute
 from pynamodb.exceptions import DoesNotExist, TransactWriteError
 from rococo.data.base import DbAdapter
-from rococo.models import BaseModel, VersionedModel
+from rococo.models import BaseModel
 from rococo.models.versioned_model import get_uuid_hex
+
+__all__ = ["DynamoDbAdapter", "DynamoOperation"]
 
 
 class DynamoOperation:
-    def __init__(self, action: str, model: Model, condition=None):
+    def __init__(
+        self,
+        action: str,
+        model: Union[Model, Type[Model]],
+        condition=None,
+        *,
+        audit_model: Type[Model] = None,
+        entity_id: str = None,
+        expected_version: str = None
+    ):
         self.action = action
         self.model = model
         self.condition = condition
+        self.audit_model = audit_model
+        self.entity_id = entity_id
+        self.expected_version = expected_version
 
 
 class DynamoDbAdapter(DbAdapter):
     """DynamoDB adapter using PynamoDB with dynamic model generation."""
 
     def __init__(self):
-        self._connections: Dict[Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]], Connection] = {}
+        self._connections: Dict[str, Connection] = {}
 
     def __enter__(self):
         return self
@@ -95,7 +110,40 @@ class DynamoDbAdapter(DbAdapter):
         class_name = f"Pynamo{model_cls.__name__}{'Audit' if is_audit else ''}"
         return type(class_name, (Model,), attrs)
 
-    def _get_connection(self, model: Model) -> Connection:
+    def _build_connection(
+        self,
+        region: str,
+        host: Optional[str],
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[str],
+        aws_session_token: Optional[str]
+    ) -> Connection:
+        return Connection(
+            region=region,
+            host=host,
+            aws_access_key_id=aws_access_key_id,
+            aws_secret_access_key=aws_secret_access_key,
+            aws_session_token=aws_session_token
+        )
+
+    def _connection_cache_key(
+        self,
+        region: str,
+        host: Optional[str],
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[str]
+    ) -> str:
+        key_material = "\x1f".join(
+            value or "" for value in (
+                region,
+                host,
+                aws_access_key_id,
+                aws_secret_access_key
+            )
+        )
+        return hashlib.sha256(key_material.encode("utf-8")).hexdigest()
+
+    def _get_connection(self, model: Union[Model, Type[Model]]) -> Connection:
         meta = getattr(model, "Meta", None)
         region = getattr(meta, "region", None) or os.getenv("AWS_REGION", "us-east-1")
         host = getattr(meta, "host", None) or os.getenv("DYNAMODB_ENDPOINT_URL")
@@ -103,14 +151,23 @@ class DynamoDbAdapter(DbAdapter):
         aws_secret_access_key = getattr(meta, "aws_secret_access_key", None) or os.getenv("AWS_SECRET_ACCESS_KEY")
         aws_session_token = getattr(meta, "aws_session_token", None) or os.getenv("AWS_SESSION_TOKEN")
 
-        key = (region, host, aws_access_key_id, aws_secret_access_key, aws_session_token)
+        if aws_session_token:
+            return self._build_connection(
+                region,
+                host,
+                aws_access_key_id,
+                aws_secret_access_key,
+                aws_session_token
+            )
+
+        key = self._connection_cache_key(region, host, aws_access_key_id, aws_secret_access_key)
         if key not in self._connections:
-            self._connections[key] = Connection(
-                region=region,
-                host=host,
-                aws_access_key_id=aws_access_key_id,
-                aws_secret_access_key=aws_secret_access_key,
-                aws_session_token=aws_session_token
+            self._connections[key] = self._build_connection(
+                region,
+                host,
+                aws_access_key_id,
+                aws_secret_access_key,
+                None
             )
         return self._connections[key]
 
@@ -118,9 +175,32 @@ class DynamoDbAdapter(DbAdapter):
         for op in ops:
             if not isinstance(op, DynamoOperation):
                 raise RuntimeError("DynamoDbAdapter.run_transaction expects only DynamoOperation objects")
-            if op.action not in {"save", "delete"}:
+            if op.action not in {"save", "delete", "audit_save"}:
                 raise RuntimeError(f"Unsupported DynamoOperation action: {op.action}")
         return ops
+
+    def _resolve_audit_operation(self, op: DynamoOperation) -> Optional[DynamoOperation]:
+        if op.audit_model is None or op.entity_id is None:
+            raise RuntimeError("Dynamo audit operation requires audit_model and entity_id")
+
+        # DynamoDB cannot read an item and write a derived audit copy in one
+        # TransactWrite action. The source read is therefore deferred until
+        # transaction execution, verified against the expected version here,
+        # and guarded again by the main-table save condition in the same write.
+        try:
+            item = op.model.get(op.entity_id, consistent_read=True)
+        except DoesNotExist:
+            return None
+
+        item_version = item.attribute_values.get("version")
+        if op.expected_version and item_version != op.expected_version:
+            raise RuntimeError(
+                f"DynamoDB audit snapshot version mismatch for entity_id={op.entity_id}: "
+                f"expected {op.expected_version}, found {item_version}"
+            )
+
+        audit_item = op.audit_model(**item.attribute_values)
+        return DynamoOperation("save", audit_item, condition=op.condition)
 
     def run_transaction(self, operations_list: List[Any]):
         """Execute operations as a single DynamoDB ACID transaction.
@@ -138,6 +218,11 @@ class DynamoDbAdapter(DbAdapter):
         try:
             with TransactWrite(connection=connection) as transaction:
                 for op in ops:
+                    if op.action == "audit_save":
+                        op = self._resolve_audit_operation(op)
+                        if op is None:
+                            continue
+
                     if op.action == "save":
                         transaction.save(op.model, condition=op.condition)
                     else:
@@ -192,7 +277,21 @@ class DynamoDbAdapter(DbAdapter):
         except Exception as e:
             raise RuntimeError(f"get_count failed: {e}")
 
-    def get_move_entity_to_audit_table_query(self, table, entity_id, model_cls: Type[BaseModel] = None):
+    def get_move_entity_to_audit_table_query(
+        self,
+        table,
+        entity_id,
+        model_cls: Type[BaseModel] = None,
+        expected_version: str = None
+    ):
+        """Return a deferred operation that snapshots the current item into audit.
+
+        The source item is read inside run_transaction, not while building the
+        operation. The main-table save operation must still carry the
+        previous_version condition; that condition is the commit-time guard that
+        aborts the whole transaction if another writer changes the source row
+        after the audit snapshot read.
+        """
         if model_cls is None:
             raise ValueError("model_cls is required for DynamoDB move_entity_to_audit_table")
 
@@ -200,16 +299,14 @@ class DynamoDbAdapter(DbAdapter):
         audit_table_name = f"{table}_audit"
         pynamo_audit_model = self._generate_pynamo_model(audit_table_name, model_cls, is_audit=True)
 
-        try:
-            item = pynamo_model.get(entity_id, consistent_read=True)
-            audit_item = pynamo_audit_model(**item.attribute_values)
-            return DynamoOperation(
-                "save",
-                audit_item,
-                condition=pynamo_audit_model.version.does_not_exist()
-            )
-        except DoesNotExist:
-            return None
+        return DynamoOperation(
+            "audit_save",
+            pynamo_model,
+            condition=pynamo_audit_model.version.does_not_exist(),
+            audit_model=pynamo_audit_model,
+            entity_id=entity_id,
+            expected_version=expected_version
+        )
 
     def move_entity_to_audit_table(self, table_name: str, entity_id: str, model_cls: Type[BaseModel] = None):
         if model_cls is None:
@@ -240,6 +337,8 @@ class DynamoDbAdapter(DbAdapter):
         # - Updated records have previous_version == the previous stored version
         previous_version = data.get("previous_version")
         if previous_version and previous_version != get_uuid_hex(0):
+            # PynamoDB exposes condition-capable attributes on the model class.
+            # Instance-level values are plain Python data and cannot build expressions.
             version_attr = getattr(pynamo_model, "version", None)
             if not isinstance(version_attr, Attribute):
                 raise RuntimeError(
@@ -259,6 +358,23 @@ class DynamoDbAdapter(DbAdapter):
         item = pynamo_model(**data)
         item.save()
         return item.attribute_values
+
+    def get_by_id(
+        self,
+        table: str,
+        entity_id: str,
+        model_cls: Type[BaseModel] = None,
+        consistent_read: bool = False
+    ) -> Optional[Dict[str, Any]]:
+        if model_cls is None:
+            raise ValueError("model_cls is required for DynamoDB get_by_id")
+
+        pynamo_model = self._generate_pynamo_model(table, model_cls)
+        try:
+            item = pynamo_model.get(entity_id, consistent_read=consistent_read)
+            return item.attribute_values
+        except DoesNotExist:
+            return None
 
     def upsert(self, table: str, data: Dict[str, Any], model_cls: Type[BaseModel] = None) -> Union[Dict[str, Any], None]:
         """

--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -11,9 +11,20 @@ from rococo.data.base import DbAdapter
 from rococo.models import BaseModel
 from rococo.models.versioned_model import get_uuid_hex
 
-__all__ = ["DynamoDbAdapter", "DynamoOperation"]
+__all__ = ["DynamoDbAdapter", "DynamoOperation", "DynamoPostCommitVersionMismatch"]
 
 MAX_TRANSACTION_ITEMS = 100
+
+
+class DynamoPostCommitVersionMismatch(RuntimeError):
+    """Raised when the strongly-consistent read-back after a successful transaction
+    commit returns a different version than expected.
+
+    This indicates a subsequent writer overwrote the committed state between the
+    transaction commit and the read-back. Callers can catch this specifically to
+    distinguish post-commit races from other RuntimeErrors.
+    """
+    pass
 
 
 @dataclass
@@ -33,7 +44,18 @@ class DynamoOperation:
 
 
 class DynamoDbAdapter(DbAdapter):
-    """DynamoDB adapter using PynamoDB with dynamic model generation."""
+    """DynamoDB adapter using PynamoDB with dynamic model generation.
+
+    Thread-safety contract:
+        The internal ``_pynamo_models`` and ``_connections`` caches use plain dicts
+        with a check-then-set pattern that is **not** atomic under concurrent access.
+        If the adapter instance is shared across threads (e.g., in a web server),
+        two threads may both create a model class or connection for the same key,
+        with one being silently discarded. This is benign (no data corruption or
+        incorrect behaviour) but wastes one redundant connection setup. If strict
+        single-instantiation semantics are required, callers should synchronize
+        access externally or use one adapter instance per thread.
+    """
 
     def __init__(self):
         self._connections: Dict[str, Connection] = {}
@@ -319,6 +341,24 @@ class DynamoDbAdapter(DbAdapter):
         return version_attr == expected_version
 
     def _resolve_audit_operation(self, op: DynamoOperation) -> DynamoOperation:
+        """Resolve a deferred audit_save into a concrete save operation.
+
+        TOCTOU note:
+            The audit snapshot is read via a strongly-consistent GetItem *before*
+            the TransactWrite batch is committed. Between this read and the commit,
+            a concurrent writer could change non-version fields on the source row.
+            The version condition (ConditionCheck or same-row save condition) guards
+            against a stale *version* being committed — if the version changes, the
+            transaction aborts. However, non-version field changes that do not
+            alter the version will slip through silently into the audit snapshot.
+
+            This is an inherent limitation of DynamoDB's TransactWriteItems API,
+            which does not support read-then-write within a single atomic action.
+            Only version integrity is guaranteed; field-level consistency of the
+            audit snapshot is best-effort.
+
+        See: https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/transaction-apis.html
+        """
         if op.audit_model is None or op.entity_id is None:
             raise RuntimeError("Dynamo audit operation requires audit_model and entity_id")
         if op.expected_version is None or op.expected_version == "":
@@ -366,7 +406,15 @@ class DynamoDbAdapter(DbAdapter):
         ops = self._validate_transaction_operations(ops)
         self._validate_transaction_item_count(ops)
         source_write_guards = self._source_write_guards(ops)
-        connection = self._get_connection(ops[0].model)
+
+        # Derive connection from the first save/delete op (which always carries a
+        # concrete model instance) rather than ops[0] which may be an audit_save
+        # class with potentially different Meta region/host.
+        connection_source = next(
+            (op.model for op in ops if op.action in {"save", "delete"}),
+            ops[0].model
+        )
+        connection = self._get_connection(connection_source)
 
         try:
             with TransactWrite(connection=connection) as transaction:
@@ -378,11 +426,7 @@ class DynamoDbAdapter(DbAdapter):
                             self._add_source_condition_check(transaction, op)
 
                     self._apply_transaction_operation(transaction, resolved_op)
-        except TransactWriteError:
-            raise
-        except ValueError:
-            raise
-        except RuntimeError:
+        except (TransactWriteError, ValueError, RuntimeError):
             raise
         except Exception as e:
             raise RuntimeError(f"Transaction failed: {e}") from e
@@ -408,7 +452,7 @@ class DynamoDbAdapter(DbAdapter):
                 return item.attribute_values
             return None
         except Exception as e:
-             raise RuntimeError(f"get_one failed: {e}")
+            raise RuntimeError(f"get_one failed: {e}")
 
     def get_many(self, table: str, conditions: Dict[str, Any] = None, sort: List[Tuple[str, str]] = None, limit: int = 100, model_cls: Type[BaseModel] = None) -> List[Dict[str, Any]]:
         model_cls = self._resolve_model_cls(table, model_cls)
@@ -487,7 +531,7 @@ class DynamoDbAdapter(DbAdapter):
         previous_version = data.get("previous_version")
         if "version" in data and previous_version is None:
             raise RuntimeError(
-                "Versioned DynamoDB save requires previous_version; use get_uuid_hex(0) for creates"
+                "Versioned DynamoDB save requires previous_version; for new records it must be the zero UUID sentinel"
             )
         if "version" in data and previous_version == "":
             raise RuntimeError("Versioned DynamoDB save requires non-empty previous_version")
@@ -510,6 +554,22 @@ class DynamoDbAdapter(DbAdapter):
         )
 
     def save(self, table: str, data: Dict[str, Any], model_cls: Type[BaseModel] = None) -> Union[Dict[str, Any], None]:
+        """Unconditional PutItem save. NOT safe for versioned models.
+
+        For versioned models, use get_save_query() + run_transaction() which
+        applies optimistic locking conditions. This method performs a plain
+        PutItem with no version guard and will silently overwrite concurrent
+        changes.
+
+        Raises:
+            RuntimeError: If data contains a 'version' field, indicating a
+                versioned model that should use the transactional save path.
+        """
+        if "version" in data:
+            raise RuntimeError(
+                "save() must not be used for versioned models — it bypasses optimistic locking. "
+                "Use get_save_query() + run_transaction() instead."
+            )
         model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)

--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -27,9 +27,9 @@ class DynamoOperation:
     action: str
     model: Union[Model, Type[Model]]
     condition: Any = None
-    audit_model: Type[Model] = None
-    entity_id: str = None
-    expected_version: str = None
+    audit_model: Optional[Type[Model]] = None
+    entity_id: Optional[str] = None
+    expected_version: Optional[str] = None
 
 
 class DynamoDbAdapter(DbAdapter):
@@ -64,15 +64,23 @@ class DynamoDbAdapter(DbAdapter):
         # Default to UnicodeAttribute for str and others
         return UnicodeAttribute(**kwargs)
 
-    def _model_cache_digest(
+    def _cache_digest(
         self,
+        purpose: str,
         region: Optional[str],
         host: Optional[str],
         aws_access_key_id: Optional[str],
         aws_secret_access_key: Optional[str]
     ) -> str:
+        """Return an opaque cache key.
+
+        Session tokens are intentionally omitted because temporary credentials
+        are not cached. The purpose prefix prevents model-cache and connection-
+        cache keys from sharing the same digest namespace.
+        """
         key_material = "\x1f".join(
             value or "" for value in (
+                purpose,
                 region,
                 host,
                 aws_access_key_id,
@@ -80,6 +88,21 @@ class DynamoDbAdapter(DbAdapter):
             )
         )
         return hashlib.sha256(key_material.encode("utf-8")).hexdigest()
+
+    def _model_cache_digest(
+        self,
+        region: Optional[str],
+        host: Optional[str],
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[str]
+    ) -> str:
+        return self._cache_digest(
+            "model",
+            region,
+            host,
+            aws_access_key_id,
+            aws_secret_access_key
+        )
 
     def _resolve_model_cls(self, table_name: str, model_cls: Type[BaseModel] = None) -> Type[BaseModel]:
         if model_cls is not None:
@@ -177,15 +200,13 @@ class DynamoDbAdapter(DbAdapter):
         aws_access_key_id: Optional[str],
         aws_secret_access_key: Optional[str]
     ) -> str:
-        key_material = "\x1f".join(
-            value or "" for value in (
-                region,
-                host,
-                aws_access_key_id,
-                aws_secret_access_key
-            )
+        return self._cache_digest(
+            "connection",
+            region,
+            host,
+            aws_access_key_id,
+            aws_secret_access_key
         )
-        return hashlib.sha256(key_material.encode("utf-8")).hexdigest()
 
     def _get_connection(self, model: Union[Model, Type[Model]]) -> Connection:
         meta = getattr(model, "Meta", None)
@@ -297,26 +318,19 @@ class DynamoDbAdapter(DbAdapter):
             )
         return version_attr == expected_version
 
-    def _resolve_audit_operation(self, op: DynamoOperation) -> Optional[DynamoOperation]:
+    def _resolve_audit_operation(self, op: DynamoOperation) -> DynamoOperation:
         if op.audit_model is None or op.entity_id is None:
             raise RuntimeError("Dynamo audit operation requires audit_model and entity_id")
         if op.expected_version is None or op.expected_version == "":
             raise RuntimeError("Dynamo audit operation requires a non-empty expected_version")
 
-        # DynamoDB cannot read an item and write a derived audit copy in one
-        # TransactWrite action. The source read is therefore deferred until
-        # transaction execution, verified against the expected version here,
-        # and guarded again by the main-table save condition in the same write.
+        # Best-effort snapshot read. The authoritative ACID boundary is the
+        # later same-row save condition or audit-only ConditionCheck.
         try:
             item = op.model.get(op.entity_id, consistent_read=True)
         except DoesNotExist:
-            return None
-
-        item_version = item.attribute_values.get("version")
-        if op.expected_version is not None and item_version != op.expected_version:
             raise RuntimeError(
-                f"DynamoDB audit snapshot version mismatch for entity_id={op.entity_id}: "
-                f"expected {op.expected_version}, found {item_version}"
+                f"DynamoDB audit snapshot source entity_id={op.entity_id} does not exist"
             )
 
         audit_item = op.audit_model(**item.attribute_values)
@@ -335,6 +349,8 @@ class DynamoDbAdapter(DbAdapter):
         elif op.action == "delete":
             transaction.delete(op.model, condition=op.condition)
         else:
+            # Defensive unreachable path: run_transaction validates actions and
+            # audit_save operations are resolved before dispatch.
             raise ValueError(f"Unknown DynamoOperation action: '{op.action}'")
 
     def run_transaction(self, operations_list: List[Any]):
@@ -358,8 +374,6 @@ class DynamoDbAdapter(DbAdapter):
                     resolved_op = op
                     if op.action == "audit_save":
                         resolved_op = self._resolve_audit_operation(op)
-                        if resolved_op is None:
-                            continue
                         if not self._is_source_guarded_by_write(op, source_write_guards):
                             self._add_source_condition_check(transaction, op)
 
@@ -367,6 +381,8 @@ class DynamoDbAdapter(DbAdapter):
         except TransactWriteError:
             raise
         except ValueError:
+            raise
+        except RuntimeError:
             raise
         except Exception as e:
             raise RuntimeError(f"Transaction failed: {e}") from e
@@ -476,7 +492,7 @@ class DynamoDbAdapter(DbAdapter):
         if "version" in data and previous_version == "":
             raise RuntimeError("Versioned DynamoDB save requires non-empty previous_version")
 
-        if previous_version and previous_version != get_uuid_hex(0):
+        if previous_version is not None and previous_version != get_uuid_hex(0):
             # PynamoDB exposes condition-capable attributes on the model class.
             # Instance-level values are plain Python data and cannot build expressions.
             condition = self._version_condition(pynamo_model, previous_version)

--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -1,3 +1,4 @@
+from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 import hashlib
 import os
@@ -12,24 +13,23 @@ from rococo.models.versioned_model import get_uuid_hex
 
 __all__ = ["DynamoDbAdapter", "DynamoOperation"]
 
+MAX_TRANSACTION_ITEMS = 100
 
+
+@dataclass
 class DynamoOperation:
-    def __init__(
-        self,
-        action: str,
-        model: Union[Model, Type[Model]],
-        condition=None,
-        *,
-        audit_model: Type[Model] = None,
-        entity_id: str = None,
-        expected_version: str = None
-    ):
-        self.action = action
-        self.model = model
-        self.condition = condition
-        self.audit_model = audit_model
-        self.entity_id = entity_id
-        self.expected_version = expected_version
+    """Typed transaction operation for DynamoDB.
+
+    For save/delete operations, `model` is a PynamoDB model instance. For
+    audit_save operations, `model` is the source PynamoDB model class and
+    `audit_model` is the destination audit model class.
+    """
+    action: str
+    model: Union[Model, Type[Model]]
+    condition: Any = None
+    audit_model: Type[Model] = None
+    entity_id: str = None
+    expected_version: str = None
 
 
 class DynamoDbAdapter(DbAdapter):
@@ -37,6 +37,8 @@ class DynamoDbAdapter(DbAdapter):
 
     def __init__(self):
         self._connections: Dict[str, Connection] = {}
+        self._pynamo_models: Dict[Tuple[str, Type[BaseModel], bool, str], Type[Model]] = {}
+        self._model_classes_by_table: Dict[str, Type[BaseModel]] = {}
 
     def __enter__(self):
         return self
@@ -62,17 +64,56 @@ class DynamoDbAdapter(DbAdapter):
         # Default to UnicodeAttribute for str and others
         return UnicodeAttribute(**kwargs)
 
+    def _model_cache_digest(
+        self,
+        region: Optional[str],
+        host: Optional[str],
+        aws_access_key_id: Optional[str],
+        aws_secret_access_key: Optional[str]
+    ) -> str:
+        key_material = "\x1f".join(
+            value or "" for value in (
+                region,
+                host,
+                aws_access_key_id,
+                aws_secret_access_key
+            )
+        )
+        return hashlib.sha256(key_material.encode("utf-8")).hexdigest()
+
+    def _resolve_model_cls(self, table_name: str, model_cls: Type[BaseModel] = None) -> Type[BaseModel]:
+        if model_cls is not None:
+            self._model_classes_by_table[table_name] = model_cls
+            return model_cls
+
+        cached_model_cls = self._model_classes_by_table.get(table_name)
+        if cached_model_cls is not None:
+            return cached_model_cls
+
+        raise ValueError("model_cls is required for DynamoDB operations until the table model has been registered")
+
     def _generate_pynamo_model(self, table_name: str, model_cls: Type[BaseModel], is_audit: bool = False) -> Type[Model]:
         """Dynamically generate a PynamoDB Model class from a Rococo BaseModel or VersionedModel."""
+        model_cls = self._resolve_model_cls(table_name, model_cls)
         
         # 1. Define Meta
         class Meta:
             table_name_val = table_name
             region = os.getenv('AWS_REGION', 'us-east-1')
-            host = os.getenv('DYNAMODB_ENDPOINT_URL')
-            aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
-            aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
-            aws_session_token = os.getenv('AWS_SESSION_TOKEN')
+            host = os.getenv('DYNAMODB_ENDPOINT_URL') or None
+            aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID') or None
+            aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY') or None
+            aws_session_token = os.getenv('AWS_SESSION_TOKEN') or None
+
+        cache_digest = self._model_cache_digest(
+            Meta.region,
+            Meta.host,
+            Meta.aws_access_key_id,
+            Meta.aws_secret_access_key
+        )
+        cache_key = (table_name, model_cls, is_audit, cache_digest)
+        if not Meta.aws_session_token and cache_key in self._pynamo_models:
+            return self._pynamo_models[cache_key]
         
         attrs = {
             'Meta': type('Meta', (), {
@@ -108,7 +149,10 @@ class DynamoDbAdapter(DbAdapter):
 
         # 3. Create class
         class_name = f"Pynamo{model_cls.__name__}{'Audit' if is_audit else ''}"
-        return type(class_name, (Model,), attrs)
+        pynamo_model = type(class_name, (Model,), attrs)
+        if not Meta.aws_session_token:
+            self._pynamo_models[cache_key] = pynamo_model
+        return pynamo_model
 
     def _build_connection(
         self,
@@ -146,10 +190,10 @@ class DynamoDbAdapter(DbAdapter):
     def _get_connection(self, model: Union[Model, Type[Model]]) -> Connection:
         meta = getattr(model, "Meta", None)
         region = getattr(meta, "region", None) or os.getenv("AWS_REGION", "us-east-1")
-        host = getattr(meta, "host", None) or os.getenv("DYNAMODB_ENDPOINT_URL")
-        aws_access_key_id = getattr(meta, "aws_access_key_id", None) or os.getenv("AWS_ACCESS_KEY_ID")
-        aws_secret_access_key = getattr(meta, "aws_secret_access_key", None) or os.getenv("AWS_SECRET_ACCESS_KEY")
-        aws_session_token = getattr(meta, "aws_session_token", None) or os.getenv("AWS_SESSION_TOKEN")
+        host = getattr(meta, "host", None) or os.getenv("DYNAMODB_ENDPOINT_URL") or None
+        aws_access_key_id = getattr(meta, "aws_access_key_id", None) or os.getenv("AWS_ACCESS_KEY_ID") or None
+        aws_secret_access_key = getattr(meta, "aws_secret_access_key", None) or os.getenv("AWS_SECRET_ACCESS_KEY") or None
+        aws_session_token = getattr(meta, "aws_session_token", None) or os.getenv("AWS_SESSION_TOKEN") or None
 
         if aws_session_token:
             return self._build_connection(
@@ -176,12 +220,88 @@ class DynamoDbAdapter(DbAdapter):
             if not isinstance(op, DynamoOperation):
                 raise RuntimeError("DynamoDbAdapter.run_transaction expects only DynamoOperation objects")
             if op.action not in {"save", "delete", "audit_save"}:
-                raise RuntimeError(f"Unsupported DynamoOperation action: {op.action}")
+                raise ValueError(f"Unknown DynamoOperation action: '{op.action}'")
         return ops
+
+    def _table_name_for(self, model: Union[Model, Type[Model]]) -> Optional[str]:
+        return getattr(getattr(model, "Meta", None), "table_name", None)
+
+    def _entity_id_for(self, model: Model) -> Optional[str]:
+        attribute_values = getattr(model, "attribute_values", {}) or {}
+        return attribute_values.get("entity_id") or getattr(model, "entity_id", None)
+
+    def _operation_source_key(self, op: DynamoOperation) -> Optional[Tuple[str, str]]:
+        if op.action == "audit_save":
+            if op.entity_id is None:
+                return None
+            table_name = self._table_name_for(op.model)
+            if table_name is None:
+                return None
+            return (table_name, op.entity_id)
+
+        if op.action in {"save", "delete"} and isinstance(op.model, Model):
+            entity_id = self._entity_id_for(op.model)
+            if entity_id is None:
+                return None
+            table_name = self._table_name_for(op.model)
+            if table_name is None:
+                return None
+            return (table_name, entity_id)
+
+        return None
+
+    def _source_write_guards(self, ops: List[DynamoOperation]) -> Dict[Tuple[str, str], str]:
+        guards: Dict[Tuple[str, str], str] = {}
+        for op in ops:
+            if op.action not in {"save", "delete"} or op.condition is None or op.expected_version is None:
+                continue
+
+            source_key = self._operation_source_key(op)
+            if source_key is not None:
+                guards[source_key] = op.expected_version
+
+        return guards
+
+    def _is_source_guarded_by_write(
+        self,
+        op: DynamoOperation,
+        source_write_guards: Dict[Tuple[str, str], str]
+    ) -> bool:
+        source_key = self._operation_source_key(op)
+        if source_key is None:
+            return False
+        return source_write_guards.get(source_key) == op.expected_version
+
+    def _estimate_transaction_item_count(self, ops: List[DynamoOperation]) -> int:
+        source_write_guards = self._source_write_guards(ops)
+        item_count = 0
+        for op in ops:
+            item_count += 1
+            if op.action == "audit_save" and not self._is_source_guarded_by_write(op, source_write_guards):
+                item_count += 1
+        return item_count
+
+    def _validate_transaction_item_count(self, ops: List[DynamoOperation]) -> None:
+        item_count = self._estimate_transaction_item_count(ops)
+        if item_count > MAX_TRANSACTION_ITEMS:
+            raise ValueError(
+                f"DynamoDB transactions support at most {MAX_TRANSACTION_ITEMS} items; got {item_count}"
+            )
+
+    def _version_condition(self, model_cls: Type[Model], expected_version: str):
+        version_attr = getattr(model_cls, "version", None)
+        if not isinstance(version_attr, Attribute):
+            table_name = self._table_name_for(model_cls) or "<unknown>"
+            raise RuntimeError(
+                f"Versioned DynamoDB operation for table '{table_name}' requires a PynamoDB 'version' attribute"
+            )
+        return version_attr == expected_version
 
     def _resolve_audit_operation(self, op: DynamoOperation) -> Optional[DynamoOperation]:
         if op.audit_model is None or op.entity_id is None:
             raise RuntimeError("Dynamo audit operation requires audit_model and entity_id")
+        if op.expected_version is None or op.expected_version == "":
+            raise RuntimeError("Dynamo audit operation requires a non-empty expected_version")
 
         # DynamoDB cannot read an item and write a derived audit copy in one
         # TransactWrite action. The source read is therefore deferred until
@@ -193,7 +313,7 @@ class DynamoDbAdapter(DbAdapter):
             return None
 
         item_version = item.attribute_values.get("version")
-        if op.expected_version and item_version != op.expected_version:
+        if op.expected_version is not None and item_version != op.expected_version:
             raise RuntimeError(
                 f"DynamoDB audit snapshot version mismatch for entity_id={op.entity_id}: "
                 f"expected {op.expected_version}, found {item_version}"
@@ -201,6 +321,21 @@ class DynamoDbAdapter(DbAdapter):
 
         audit_item = op.audit_model(**item.attribute_values)
         return DynamoOperation("save", audit_item, condition=op.condition)
+
+    def _add_source_condition_check(self, transaction, op: DynamoOperation) -> None:
+        transaction.condition_check(
+            op.model,
+            op.entity_id,
+            condition=self._version_condition(op.model, op.expected_version)
+        )
+
+    def _apply_transaction_operation(self, transaction, op: DynamoOperation) -> None:
+        if op.action == "save":
+            transaction.save(op.model, condition=op.condition)
+        elif op.action == "delete":
+            transaction.delete(op.model, condition=op.condition)
+        else:
+            raise ValueError(f"Unknown DynamoOperation action: '{op.action}'")
 
     def run_transaction(self, operations_list: List[Any]):
         """Execute operations as a single DynamoDB ACID transaction.
@@ -213,21 +348,25 @@ class DynamoDbAdapter(DbAdapter):
             return
 
         ops = self._validate_transaction_operations(ops)
+        self._validate_transaction_item_count(ops)
+        source_write_guards = self._source_write_guards(ops)
         connection = self._get_connection(ops[0].model)
 
         try:
             with TransactWrite(connection=connection) as transaction:
                 for op in ops:
+                    resolved_op = op
                     if op.action == "audit_save":
-                        op = self._resolve_audit_operation(op)
-                        if op is None:
+                        resolved_op = self._resolve_audit_operation(op)
+                        if resolved_op is None:
                             continue
+                        if not self._is_source_guarded_by_write(op, source_write_guards):
+                            self._add_source_condition_check(transaction, op)
 
-                    if op.action == "save":
-                        transaction.save(op.model, condition=op.condition)
-                    else:
-                        transaction.delete(op.model, condition=op.condition)
+                    self._apply_transaction_operation(transaction, resolved_op)
         except TransactWriteError:
+            raise
+        except ValueError:
             raise
         except Exception as e:
             raise RuntimeError(f"Transaction failed: {e}") from e
@@ -243,8 +382,7 @@ class DynamoDbAdapter(DbAdapter):
         return response
 
     def get_one(self, table: str, conditions: Dict[str, Any], sort: List[Tuple[str, str]] = None, model_cls: Type[BaseModel] = None) -> Dict[str, Any]:
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB get_one")
+        model_cls = self._resolve_model_cls(table, model_cls)
             
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         try:
@@ -257,8 +395,7 @@ class DynamoDbAdapter(DbAdapter):
              raise RuntimeError(f"get_one failed: {e}")
 
     def get_many(self, table: str, conditions: Dict[str, Any] = None, sort: List[Tuple[str, str]] = None, limit: int = 100, model_cls: Type[BaseModel] = None) -> List[Dict[str, Any]]:
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB get_many")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         try:
@@ -268,8 +405,7 @@ class DynamoDbAdapter(DbAdapter):
             raise RuntimeError(f"get_many failed: {e}")
 
     def get_count(self, table: str, conditions: Dict[str, Any], options: Optional[Dict[str, Any]] = None, model_cls: Type[BaseModel] = None) -> int:
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB get_count")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         try:
@@ -292,8 +428,7 @@ class DynamoDbAdapter(DbAdapter):
         aborts the whole transaction if another writer changes the source row
         after the audit snapshot read.
         """
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB move_entity_to_audit_table")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         audit_table_name = f"{table}_audit"
@@ -309,8 +444,7 @@ class DynamoDbAdapter(DbAdapter):
         )
 
     def move_entity_to_audit_table(self, table_name: str, entity_id: str, model_cls: Type[BaseModel] = None):
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB move_entity_to_audit_table")
+        model_cls = self._resolve_model_cls(table_name, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table_name, model_cls)
         audit_table_name = f"{table_name}_audit"
@@ -326,8 +460,7 @@ class DynamoDbAdapter(DbAdapter):
             raise RuntimeError(f"move_entity_to_audit_table failed: {e}")
 
     def get_save_query(self, table: str, data: Dict[str, Any], model_cls: Type[BaseModel] = None):
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB save")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         item = pynamo_model(**data)
@@ -336,23 +469,32 @@ class DynamoDbAdapter(DbAdapter):
         # - New records have previous_version == ZERO_UUID (set by prepare_for_save)
         # - Updated records have previous_version == the previous stored version
         previous_version = data.get("previous_version")
+        if "version" in data and previous_version is None:
+            raise RuntimeError(
+                "Versioned DynamoDB save requires previous_version; use get_uuid_hex(0) for creates"
+            )
+        if "version" in data and previous_version == "":
+            raise RuntimeError("Versioned DynamoDB save requires non-empty previous_version")
+
         if previous_version and previous_version != get_uuid_hex(0):
             # PynamoDB exposes condition-capable attributes on the model class.
             # Instance-level values are plain Python data and cannot build expressions.
-            version_attr = getattr(pynamo_model, "version", None)
-            if not isinstance(version_attr, Attribute):
-                raise RuntimeError(
-                    f"Versioned DynamoDB save for table '{table}' requires a PynamoDB 'version' attribute"
-                )
-            condition = (version_attr == previous_version)
+            condition = self._version_condition(pynamo_model, previous_version)
+            operation_expected_version = previous_version
         else:
             condition = pynamo_model.entity_id.does_not_exist()
+            operation_expected_version = None
 
-        return DynamoOperation("save", item, condition=condition)
+        return DynamoOperation(
+            "save",
+            item,
+            condition=condition,
+            entity_id=data.get("entity_id"),
+            expected_version=operation_expected_version
+        )
 
     def save(self, table: str, data: Dict[str, Any], model_cls: Type[BaseModel] = None) -> Union[Dict[str, Any], None]:
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB save")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         item = pynamo_model(**data)
@@ -366,8 +508,7 @@ class DynamoDbAdapter(DbAdapter):
         model_cls: Type[BaseModel] = None,
         consistent_read: bool = False
     ) -> Optional[Dict[str, Any]]:
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB get_by_id")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         try:
@@ -395,8 +536,7 @@ class DynamoDbAdapter(DbAdapter):
             ValueError: If model_cls is not provided.
             RuntimeError: If entity_id is missing or any DynamoDB operation fails.
         """
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB upsert")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         if 'entity_id' not in data:
             raise RuntimeError("upsert failed: 'entity_id' is required in data")
@@ -410,8 +550,7 @@ class DynamoDbAdapter(DbAdapter):
             raise RuntimeError(f"upsert failed: {e}")
 
     def delete(self, table: str, data: Dict[str, Any], model_cls: Type[BaseModel] = None) -> bool:
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB delete")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         entity_id = data.get('entity_id')
@@ -427,8 +566,7 @@ class DynamoDbAdapter(DbAdapter):
 
     def hard_delete(self, table: str, entity_id: str, model_cls: Type[BaseModel] = None) -> bool:
         """Permanently deletes a record from the specified table by entity_id."""
-        if model_cls is None:
-            raise ValueError("model_cls is required for DynamoDB hard_delete")
+        model_cls = self._resolve_model_cls(table, model_cls)
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         try:

--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -3,10 +3,11 @@ import os
 from pynamodb.models import Model
 from pynamodb.connection import Connection
 from pynamodb.transactions import TransactWrite
-from pynamodb.attributes import UnicodeAttribute, BooleanAttribute, NumberAttribute, JSONAttribute, UTCDateTimeAttribute, ListAttribute
-from pynamodb.exceptions import DoesNotExist
+from pynamodb.attributes import Attribute, UnicodeAttribute, BooleanAttribute, NumberAttribute, JSONAttribute, UTCDateTimeAttribute, ListAttribute
+from pynamodb.exceptions import DoesNotExist, TransactWriteError
 from rococo.data.base import DbAdapter
 from rococo.models import BaseModel, VersionedModel
+from rococo.models.versioned_model import get_uuid_hex
 
 
 class DynamoOperation:
@@ -20,7 +21,7 @@ class DynamoDbAdapter(DbAdapter):
     """DynamoDB adapter using PynamoDB with dynamic model generation."""
 
     def __init__(self):
-        pass
+        self._connections: Dict[Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]], Connection] = {}
 
     def __enter__(self):
         return self
@@ -53,15 +54,19 @@ class DynamoDbAdapter(DbAdapter):
         class Meta:
             table_name_val = table_name
             region = os.getenv('AWS_REGION', 'us-east-1')
+            host = os.getenv('DYNAMODB_ENDPOINT_URL')
             aws_access_key_id = os.getenv('AWS_ACCESS_KEY_ID')
             aws_secret_access_key = os.getenv('AWS_SECRET_ACCESS_KEY')
+            aws_session_token = os.getenv('AWS_SESSION_TOKEN')
         
         attrs = {
             'Meta': type('Meta', (), {
                 'table_name': Meta.table_name_val,
                 'region': Meta.region,
+                'host': Meta.host,
                 'aws_access_key_id': Meta.aws_access_key_id,
-                'aws_secret_access_key': Meta.aws_secret_access_key
+                'aws_secret_access_key': Meta.aws_secret_access_key,
+                'aws_session_token': Meta.aws_session_token
             })
         }
 
@@ -90,6 +95,33 @@ class DynamoDbAdapter(DbAdapter):
         class_name = f"Pynamo{model_cls.__name__}{'Audit' if is_audit else ''}"
         return type(class_name, (Model,), attrs)
 
+    def _get_connection(self, model: Model) -> Connection:
+        meta = getattr(model, "Meta", None)
+        region = getattr(meta, "region", None) or os.getenv("AWS_REGION", "us-east-1")
+        host = getattr(meta, "host", None) or os.getenv("DYNAMODB_ENDPOINT_URL")
+        aws_access_key_id = getattr(meta, "aws_access_key_id", None) or os.getenv("AWS_ACCESS_KEY_ID")
+        aws_secret_access_key = getattr(meta, "aws_secret_access_key", None) or os.getenv("AWS_SECRET_ACCESS_KEY")
+        aws_session_token = getattr(meta, "aws_session_token", None) or os.getenv("AWS_SESSION_TOKEN")
+
+        key = (region, host, aws_access_key_id, aws_secret_access_key, aws_session_token)
+        if key not in self._connections:
+            self._connections[key] = Connection(
+                region=region,
+                host=host,
+                aws_access_key_id=aws_access_key_id,
+                aws_secret_access_key=aws_secret_access_key,
+                aws_session_token=aws_session_token
+            )
+        return self._connections[key]
+
+    def _validate_transaction_operations(self, ops: List[Any]) -> List["DynamoOperation"]:
+        for op in ops:
+            if not isinstance(op, DynamoOperation):
+                raise RuntimeError("DynamoDbAdapter.run_transaction expects only DynamoOperation objects")
+            if op.action not in {"save", "delete"}:
+                raise RuntimeError(f"Unsupported DynamoOperation action: {op.action}")
+        return ops
+
     def run_transaction(self, operations_list: List[Any]):
         """Execute operations as a single DynamoDB ACID transaction.
 
@@ -100,28 +132,20 @@ class DynamoDbAdapter(DbAdapter):
         if not ops:
             return
 
-        first_op = ops[0]
-        if not isinstance(first_op, DynamoOperation):
-            raise RuntimeError("DynamoDbAdapter.run_transaction expects DynamoOperation objects")
-
-        region = getattr(getattr(first_op.model, "Meta", None), "region", None) or os.getenv(
-            "AWS_REGION", "us-east-1"
-        )
-        connection = Connection(region=region)
+        ops = self._validate_transaction_operations(ops)
+        connection = self._get_connection(ops[0].model)
 
         try:
             with TransactWrite(connection=connection) as transaction:
                 for op in ops:
-                    if not isinstance(op, DynamoOperation):
-                        raise RuntimeError("DynamoDbAdapter.run_transaction expects only DynamoOperation objects")
                     if op.action == "save":
                         transaction.save(op.model, condition=op.condition)
-                    elif op.action == "delete":
-                        transaction.delete(op.model, condition=op.condition)
                     else:
-                        raise RuntimeError(f"Unsupported DynamoOperation action: {op.action}")
+                        transaction.delete(op.model, condition=op.condition)
+        except TransactWriteError:
+            raise
         except Exception as e:
-            raise RuntimeError(f"Transaction failed: {e}")
+            raise RuntimeError(f"Transaction failed: {e}") from e
 
     def execute_query(self, sql: str, _vars: Dict[str, Any] = None) -> Any:
         raise NotImplementedError("execute_query is not supported for DynamoDB")
@@ -177,9 +201,13 @@ class DynamoDbAdapter(DbAdapter):
         pynamo_audit_model = self._generate_pynamo_model(audit_table_name, model_cls, is_audit=True)
 
         try:
-            item = pynamo_model.get(entity_id)
+            item = pynamo_model.get(entity_id, consistent_read=True)
             audit_item = pynamo_audit_model(**item.attribute_values)
-            return DynamoOperation("save", audit_item)
+            return DynamoOperation(
+                "save",
+                audit_item,
+                condition=pynamo_audit_model.version.does_not_exist()
+            )
         except DoesNotExist:
             return None
 
@@ -192,7 +220,7 @@ class DynamoDbAdapter(DbAdapter):
         pynamo_audit_model = self._generate_pynamo_model(audit_table_name, model_cls, is_audit=True)
 
         try:
-            item = pynamo_model.get(entity_id)
+            item = pynamo_model.get(entity_id, consistent_read=True)
             audit_item = pynamo_audit_model(**item.attribute_values)
             audit_item.save()
         except DoesNotExist:
@@ -211,8 +239,13 @@ class DynamoDbAdapter(DbAdapter):
         # - New records have previous_version == ZERO_UUID (set by prepare_for_save)
         # - Updated records have previous_version == the previous stored version
         previous_version = data.get("previous_version")
-        if previous_version and previous_version != "00000000000040008000000000000000":
-            condition = (pynamo_model.version == previous_version)
+        if previous_version and previous_version != get_uuid_hex(0):
+            version_attr = getattr(pynamo_model, "version", None)
+            if not isinstance(version_attr, Attribute):
+                raise RuntimeError(
+                    f"Versioned DynamoDB save for table '{table}' requires a PynamoDB 'version' attribute"
+                )
+            condition = (version_attr == previous_version)
         else:
             condition = pynamo_model.entity_id.does_not_exist()
 

--- a/rococo/repositories/dynamodb/dynamodb_repository.py
+++ b/rococo/repositories/dynamodb/dynamodb_repository.py
@@ -45,7 +45,7 @@ class DynamoDbRepository(BaseRepository):
         )
         return data
 
-    def _read_committed_state(self, entity_id: str) -> Dict[str, Any]:
+    def _read_committed_state(self, entity_id: str, expected_version: str = None) -> Dict[str, Any]:
         saved = self._execute_within_context(
             lambda: self.adapter.get_by_id(
                 table=self.table_name,
@@ -57,6 +57,11 @@ class DynamoDbRepository(BaseRepository):
         if not saved:
             raise RuntimeError(
                 f"DynamoDB transaction committed but entity_id={entity_id} could not be read back"
+            )
+        if expected_version is not None and saved.get("version") != expected_version:
+            raise RuntimeError(
+                f"DynamoDB transaction committed version={expected_version}, "
+                f"but read back version={saved.get('version')} for entity_id={entity_id}"
             )
         return saved
 
@@ -147,7 +152,7 @@ class DynamoDbRepository(BaseRepository):
             )
 
             self._execute_within_context(lambda: self.adapter.run_transaction(ops))
-            saved = self._read_committed_state(payload["entity_id"])
+            saved = self._read_committed_state(payload["entity_id"], expected_version=payload.get("version"))
         else:
             saved = self._execute_within_context(
                 lambda: self.adapter.upsert(self.table_name, payload, model_cls=self.model)
@@ -218,7 +223,7 @@ class DynamoDbRepository(BaseRepository):
             )
 
             self._execute_within_context(lambda: self.adapter.run_transaction(ops))
-            saved = self._read_committed_state(data["entity_id"])
+            saved = self._read_committed_state(data["entity_id"], expected_version=data.get("version"))
 
             if saved:
                 for k, v in saved.items():

--- a/rococo/repositories/dynamodb/dynamodb_repository.py
+++ b/rococo/repositories/dynamodb/dynamodb_repository.py
@@ -2,7 +2,7 @@ import json
 import logging
 from uuid import UUID
 from typing import Any, Dict, List, Optional, Type, Tuple
-from rococo.data.dynamodb import DynamoDbAdapter
+from rococo.data.dynamodb import DynamoDbAdapter, DynamoPostCommitVersionMismatch
 from rococo.messaging import MessageAdapter
 from rococo.repositories import BaseRepository
 from rococo.models.versioned_model import BaseModel, VersionedModel, get_uuid_hex
@@ -59,7 +59,7 @@ class DynamoDbRepository(BaseRepository):
                 f"DynamoDB transaction committed but entity_id={entity_id} could not be read back"
             )
         if expected_version is not None and saved.get("version") != expected_version:
-            raise RuntimeError(
+            raise DynamoPostCommitVersionMismatch(
                 f"DynamoDB write succeeded with version={expected_version}, but the strongly consistent "
                 f"read-back returned version={saved.get('version')} for entity_id={entity_id}. "
                 "The committed write may have been superseded by a subsequent writer; do not retry blindly."
@@ -135,14 +135,14 @@ class DynamoDbRepository(BaseRepository):
             if self.use_audit_table:
                 previous_version = getattr(instance, 'previous_version', None)
                 if previous_version is not None and previous_version != get_uuid_hex(0):
-                    audit_op = self.adapter.get_move_entity_to_audit_table_query(
-                        self.table_name,
-                        instance.entity_id,
-                        model_cls=self.model,
-                        expected_version=previous_version
+                    ops.append(
+                        self.adapter.get_move_entity_to_audit_table_query(
+                            self.table_name,
+                            instance.entity_id,
+                            model_cls=self.model,
+                            expected_version=previous_version
+                        )
                     )
-                    if audit_op:
-                        ops.append(audit_op)
 
             ops.append(
                 self.adapter.get_save_query(
@@ -206,14 +206,14 @@ class DynamoDbRepository(BaseRepository):
             if self.use_audit_table:
                 previous_version = getattr(instance, 'previous_version', None)
                 if previous_version is not None and previous_version != get_uuid_hex(0):
-                    audit_op = self.adapter.get_move_entity_to_audit_table_query(
-                        self.table_name,
-                        data['entity_id'],
-                        model_cls=self.model,
-                        expected_version=previous_version
+                    ops.append(
+                        self.adapter.get_move_entity_to_audit_table_query(
+                            self.table_name,
+                            data['entity_id'],
+                            model_cls=self.model,
+                            expected_version=previous_version
+                        )
                     )
-                    if audit_op:
-                        ops.append(audit_op)
 
             ops.append(
                 self.adapter.get_save_query(
@@ -232,12 +232,8 @@ class DynamoDbRepository(BaseRepository):
                         setattr(instance, k, v)
         else:
             # Hard delete for non-versioned models
-            with self.adapter:
-                pynamo_model = self.adapter._generate_pynamo_model(self.table_name, self.model)
-                try:
-                    item = pynamo_model.get(instance.entity_id)
-                    item.delete()
-                except Exception as e:
-                    self.logger.warning(f"Could not delete entity: {e}")
+            self._execute_within_context(
+                lambda: self.adapter.hard_delete(self.table_name, instance.entity_id, model_cls=self.model)
+            )
 
         return instance

--- a/rococo/repositories/dynamodb/dynamodb_repository.py
+++ b/rococo/repositories/dynamodb/dynamodb_repository.py
@@ -45,6 +45,21 @@ class DynamoDbRepository(BaseRepository):
         )
         return data
 
+    def _read_committed_state(self, entity_id: str) -> Dict[str, Any]:
+        saved = self._execute_within_context(
+            lambda: self.adapter.get_by_id(
+                table=self.table_name,
+                entity_id=entity_id,
+                model_cls=self.model,
+                consistent_read=True
+            )
+        )
+        if not saved:
+            raise RuntimeError(
+                f"DynamoDB transaction committed but entity_id={entity_id} could not be read back"
+            )
+        return saved
+
     def get_one(
         self,
         conditions: Dict[str, Any],
@@ -117,7 +132,8 @@ class DynamoDbRepository(BaseRepository):
                     audit_op = self.adapter.get_move_entity_to_audit_table_query(
                         self.table_name,
                         instance.entity_id,
-                        model_cls=self.model
+                        model_cls=self.model,
+                        expected_version=previous_version
                     )
                     if audit_op:
                         ops.append(audit_op)
@@ -131,7 +147,7 @@ class DynamoDbRepository(BaseRepository):
             )
 
             self._execute_within_context(lambda: self.adapter.run_transaction(ops))
-            saved = payload
+            saved = self._read_committed_state(payload["entity_id"])
         else:
             saved = self._execute_within_context(
                 lambda: self.adapter.upsert(self.table_name, payload, model_cls=self.model)
@@ -187,7 +203,8 @@ class DynamoDbRepository(BaseRepository):
                     audit_op = self.adapter.get_move_entity_to_audit_table_query(
                         self.table_name,
                         data['entity_id'],
-                        model_cls=self.model
+                        model_cls=self.model,
+                        expected_version=previous_version
                     )
                     if audit_op:
                         ops.append(audit_op)
@@ -201,7 +218,7 @@ class DynamoDbRepository(BaseRepository):
             )
 
             self._execute_within_context(lambda: self.adapter.run_transaction(ops))
-            saved = data
+            saved = self._read_committed_state(data["entity_id"])
 
             if saved:
                 for k, v in saved.items():

--- a/rococo/repositories/dynamodb/dynamodb_repository.py
+++ b/rococo/repositories/dynamodb/dynamodb_repository.py
@@ -45,7 +45,7 @@ class DynamoDbRepository(BaseRepository):
         )
         return data
 
-    def _read_committed_state(self, entity_id: str, expected_version: str = None) -> Dict[str, Any]:
+    def _read_committed_state(self, entity_id: str, expected_version: Optional[str] = None) -> Dict[str, Any]:
         saved = self._execute_within_context(
             lambda: self.adapter.get_by_id(
                 table=self.table_name,
@@ -60,8 +60,9 @@ class DynamoDbRepository(BaseRepository):
             )
         if expected_version is not None and saved.get("version") != expected_version:
             raise RuntimeError(
-                f"DynamoDB transaction committed version={expected_version}, "
-                f"but read back version={saved.get('version')} for entity_id={entity_id}"
+                f"DynamoDB write succeeded with version={expected_version}, but the strongly consistent "
+                f"read-back returned version={saved.get('version')} for entity_id={entity_id}. "
+                "The committed write may have been superseded by a subsequent writer; do not retry blindly."
             )
         return saved
 
@@ -133,7 +134,7 @@ class DynamoDbRepository(BaseRepository):
 
             if self.use_audit_table:
                 previous_version = getattr(instance, 'previous_version', None)
-                if previous_version and previous_version != get_uuid_hex(0):
+                if previous_version is not None and previous_version != get_uuid_hex(0):
                     audit_op = self.adapter.get_move_entity_to_audit_table_query(
                         self.table_name,
                         instance.entity_id,
@@ -204,7 +205,7 @@ class DynamoDbRepository(BaseRepository):
 
             if self.use_audit_table:
                 previous_version = getattr(instance, 'previous_version', None)
-                if previous_version and previous_version != get_uuid_hex(0):
+                if previous_version is not None and previous_version != get_uuid_hex(0):
                     audit_op = self.adapter.get_move_entity_to_audit_table_query(
                         self.table_name,
                         data['entity_id'],

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.2.0',
+    version='1.2.1',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -159,6 +159,7 @@ class TestDynamoDbRepository(unittest.TestCase):
                 'first_name': 'Jane',
                 'last_name': 'Persisted',
                 'active': True,
+                'version': person.version,
             }
             transact_patch = patch('rococo.data.dynamodb.TransactWrite')
             mock_transact_write = transact_patch.start()
@@ -230,6 +231,7 @@ class TestDynamoDbRepository(unittest.TestCase):
                 self.assertIn("attribute_not_exists", str(audit_condition))
                 self.assertIn("version", str(audit_condition))
                 self.assertIn(old_version, str(save_condition))
+                mock_tx.condition_check.assert_not_called()
                 mock_get_by_id.assert_called_once()
 
                 # Verify message was sent
@@ -244,6 +246,7 @@ class TestDynamoDbRepository(unittest.TestCase):
                 'entity_id': entity_id,
                 'first_name': 'Jane',
                 'active': False,
+                'version': person.version,
             }
             transact_patch = patch('rococo.data.dynamodb.TransactWrite')
             mock_transact_write = transact_patch.start()
@@ -300,6 +303,59 @@ class TestDynamoDbRepository(unittest.TestCase):
 
         mock_tx.save.assert_not_called()
 
+    def test_audit_operation_rejects_empty_expected_version(self):
+        entity_id = uuid4().hex
+        operation = self.adapter.get_move_entity_to_audit_table_query(
+            'person',
+            entity_id,
+            model_cls=Person,
+            expected_version=""
+        )
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+                mock_tx = MagicMock()
+                mock_transact_write.return_value.__enter__.return_value = mock_tx
+
+                with self.assertRaisesRegex(RuntimeError, "non-empty expected_version"):
+                    self.adapter.run_transaction([operation])
+
+        mock_get.assert_not_called()
+        mock_tx.save.assert_not_called()
+
+    def test_audit_only_operation_adds_source_condition_check(self):
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+        operation = self.adapter.get_move_entity_to_audit_table_query(
+            'person',
+            entity_id,
+            model_cls=Person,
+            expected_version=old_version
+        )
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            mock_item = MagicMock()
+            mock_item.attribute_values = {
+                'entity_id': entity_id,
+                'first_name': 'Jane',
+                'active': True,
+                'version': old_version,
+            }
+            mock_get.return_value = mock_item
+
+            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+                mock_tx = MagicMock()
+                mock_transact_write.return_value.__enter__.return_value = mock_tx
+
+                self.adapter.run_transaction([operation])
+
+        mock_tx.condition_check.assert_called_once()
+        condition_check_call = mock_tx.condition_check.call_args
+        self.assertIs(condition_check_call.args[0], PersonModel)
+        self.assertEqual(condition_check_call.args[1], entity_id)
+        self.assertIn(old_version, str(condition_check_call.kwargs["condition"]))
+        mock_tx.save.assert_called_once()
+
     def test_get_save_query_uses_shared_zero_uuid_sentinel(self):
         data = {
             'entity_id': uuid4().hex,
@@ -324,6 +380,25 @@ class TestDynamoDbRepository(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "requires a PynamoDB 'version' attribute"):
                 self.adapter.get_save_query('person', data, model_cls=Person)
 
+    def test_get_save_query_rejects_missing_previous_version_for_versioned_data(self):
+        data = {
+            'entity_id': uuid4().hex,
+            'version': uuid4().hex,
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "requires previous_version"):
+            self.adapter.get_save_query('person', data, model_cls=Person)
+
+    def test_get_save_query_rejects_empty_previous_version_for_versioned_data(self):
+        data = {
+            'entity_id': uuid4().hex,
+            'version': uuid4().hex,
+            'previous_version': "",
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "non-empty previous_version"):
+            self.adapter.get_save_query('person', data, model_cls=Person)
+
     def test_run_transaction_reraises_transact_write_error(self):
         operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
         error = TransactWriteError("conditional check failed")
@@ -343,6 +418,29 @@ class TestDynamoDbRepository(unittest.TestCase):
             with self.assertRaisesRegex(RuntimeError, "expects only DynamoOperation objects"):
                 self.adapter.run_transaction([valid_operation, object()])
 
+        mock_transact_write.assert_not_called()
+
+    def test_run_transaction_rejects_unknown_action_before_opening_transaction(self):
+        operation = DynamoOperation("typo", PersonModel(entity_id=uuid4().hex))
+
+        with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+            with self.assertRaisesRegex(ValueError, "Unknown DynamoOperation action"):
+                self.adapter.run_transaction([operation])
+
+        mock_transact_write.assert_not_called()
+
+    def test_run_transaction_enforces_dynamodb_item_limit(self):
+        operations = [
+            DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
+            for _ in range(101)
+        ]
+
+        with patch('rococo.data.dynamodb.Connection') as mock_connection:
+            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+                with self.assertRaisesRegex(ValueError, "at most 100 items"):
+                    self.adapter.run_transaction(operations)
+
+        mock_connection.assert_not_called()
         mock_transact_write.assert_not_called()
 
     def test_run_transaction_reuses_cached_connection(self):
@@ -368,6 +466,50 @@ class TestDynamoDbRepository(unittest.TestCase):
                     adapter.run_transaction([operation])
 
         self.assertNotIn(secret, repr(adapter._connections))
+
+    def test_generated_pynamo_model_is_cached_without_session_token(self):
+        adapter = DynamoDbAdapter()
+
+        with patch.dict(os.environ, {'AWS_SESSION_TOKEN': ''}):
+            first_model = adapter._generate_pynamo_model('person', Person)
+            second_model = adapter._generate_pynamo_model('person', Person)
+
+        self.assertIs(first_model, second_model)
+
+    def test_get_move_entity_to_audit_table_query_can_use_registered_model_cls(self):
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+        self.adapter.get_save_query(
+            'person',
+            {
+                'entity_id': entity_id,
+                'version': uuid4().hex,
+                'previous_version': get_uuid_hex(0),
+            },
+            model_cls=Person
+        )
+
+        operation = self.adapter.get_move_entity_to_audit_table_query(
+            'person',
+            entity_id,
+            expected_version=old_version
+        )
+
+        self.assertEqual(operation.action, "audit_save")
+        self.assertEqual(operation.expected_version, old_version)
+
+    def test_read_committed_state_rejects_version_mismatch(self):
+        entity_id = uuid4().hex
+        expected_version = uuid4().hex
+
+        with patch.object(self.adapter, 'get_by_id') as mock_get_by_id:
+            mock_get_by_id.return_value = {
+                'entity_id': entity_id,
+                'version': uuid4().hex,
+            }
+
+            with self.assertRaisesRegex(RuntimeError, "read back version"):
+                self.repository._read_committed_state(entity_id, expected_version=expected_version)
 
     def test_session_token_connections_are_not_cached(self):
         adapter = DynamoDbAdapter()

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -153,13 +153,25 @@ class TestDynamoDbRepository(unittest.TestCase):
         # Test saving a new record
         person = Person(first_name='Jane', last_name='Doe')
 
-        with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+        with patch.object(self.adapter, 'get_by_id') as mock_get_by_id:
+            mock_get_by_id.side_effect = lambda table, entity_id, model_cls, consistent_read: {
+                'entity_id': entity_id,
+                'first_name': 'Jane',
+                'last_name': 'Persisted',
+                'active': True,
+            }
+            transact_patch = patch('rococo.data.dynamodb.TransactWrite')
+            mock_transact_write = transact_patch.start()
+            self.addCleanup(transact_patch.stop)
             mock_tx = MagicMock()
             mock_transact_write.return_value.__enter__.return_value = mock_tx
 
             saved_person = self.repository.save(person, send_message=True)
 
             self.assertEqual(saved_person.first_name, 'Jane')
+            self.assertEqual(saved_person.last_name, 'Persisted')
+            mock_get_by_id.assert_called_once()
+            self.assertTrue(mock_get_by_id.call_args.kwargs["consistent_read"])
             mock_tx.save.assert_called()
             condition = mock_tx.save.call_args.kwargs["condition"]
             self.assertIn("attribute_not_exists", str(condition))
@@ -183,10 +195,26 @@ class TestDynamoDbRepository(unittest.TestCase):
         # Mock the 'get' call used by move_entity_to_audit_table
         with patch.object(PersonModel, 'get') as mock_get:
             mock_item = MagicMock()
-            mock_item.attribute_values = {'entity_id': entity_id, 'first_name': 'Jane', 'active': True}
+            mock_item.attribute_values = {
+                'entity_id': entity_id,
+                'first_name': 'Jane',
+                'active': True,
+                'version': old_version,
+            }
             mock_get.return_value = mock_item
             
-            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+            with patch.object(self.adapter, 'get_by_id') as mock_get_by_id:
+                mock_get_by_id.side_effect = lambda table, entity_id, model_cls, consistent_read: {
+                    'entity_id': entity_id,
+                    'first_name': 'Jane',
+                    'last_name': 'Doe',
+                    'active': True,
+                    'version': person.version,
+                    'previous_version': old_version,
+                }
+                transact_patch = patch('rococo.data.dynamodb.TransactWrite')
+                mock_transact_write = transact_patch.start()
+                self.addCleanup(transact_patch.stop)
                 mock_tx = MagicMock()
                 mock_transact_write.return_value.__enter__.return_value = mock_tx
 
@@ -202,6 +230,7 @@ class TestDynamoDbRepository(unittest.TestCase):
                 self.assertIn("attribute_not_exists", str(audit_condition))
                 self.assertIn("version", str(audit_condition))
                 self.assertIn(old_version, str(save_condition))
+                mock_get_by_id.assert_called_once()
 
                 # Verify message was sent
                 self.message_adapter.send_message.assert_called()
@@ -210,12 +239,66 @@ class TestDynamoDbRepository(unittest.TestCase):
         person = Person(first_name='Jane')
         person.entity_id = uuid4().hex
 
-        with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+        with patch.object(self.adapter, 'get_by_id') as mock_get_by_id:
+            mock_get_by_id.side_effect = lambda table, entity_id, model_cls, consistent_read: {
+                'entity_id': entity_id,
+                'first_name': 'Jane',
+                'active': False,
+            }
+            transact_patch = patch('rococo.data.dynamodb.TransactWrite')
+            mock_transact_write = transact_patch.start()
+            self.addCleanup(transact_patch.stop)
             mock_tx = MagicMock()
             mock_transact_write.return_value.__enter__.return_value = mock_tx
 
             self.repository.delete(person)
+            self.assertFalse(person.active)
+            mock_get_by_id.assert_called_once()
             mock_tx.save.assert_called()
+
+    def test_get_move_entity_to_audit_table_query_is_deferred(self):
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            operation = self.adapter.get_move_entity_to_audit_table_query(
+                'person',
+                entity_id,
+                model_cls=Person,
+                expected_version=old_version
+            )
+
+        mock_get.assert_not_called()
+        self.assertEqual(operation.action, "audit_save")
+        self.assertEqual(operation.entity_id, entity_id)
+        self.assertEqual(operation.expected_version, old_version)
+
+    def test_audit_operation_rejects_snapshot_version_mismatch(self):
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+        operation = self.adapter.get_move_entity_to_audit_table_query(
+            'person',
+            entity_id,
+            model_cls=Person,
+            expected_version=old_version
+        )
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            mock_item = MagicMock()
+            mock_item.attribute_values = {
+                'entity_id': entity_id,
+                'version': uuid4().hex,
+            }
+            mock_get.return_value = mock_item
+
+            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+                mock_tx = MagicMock()
+                mock_transact_write.return_value.__enter__.return_value = mock_tx
+
+                with self.assertRaisesRegex(RuntimeError, "audit snapshot version mismatch"):
+                    self.adapter.run_transaction([operation])
+
+        mock_tx.save.assert_not_called()
 
     def test_get_save_query_uses_shared_zero_uuid_sentinel(self):
         data = {
@@ -263,14 +346,46 @@ class TestDynamoDbRepository(unittest.TestCase):
         mock_transact_write.assert_not_called()
 
     def test_run_transaction_reuses_cached_connection(self):
+        adapter = DynamoDbAdapter()
         operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
 
-        with patch('rococo.data.dynamodb.Connection') as mock_connection:
-            with patch('rococo.data.dynamodb.TransactWrite'):
-                self.adapter.run_transaction([operation])
-                self.adapter.run_transaction([operation])
+        with patch.dict(os.environ, {'AWS_SESSION_TOKEN': ''}):
+            with patch('rococo.data.dynamodb.Connection') as mock_connection:
+                with patch('rococo.data.dynamodb.TransactWrite'):
+                    adapter.run_transaction([operation])
+                    adapter.run_transaction([operation])
 
         self.assertEqual(mock_connection.call_count, 1)
+
+    def test_connection_cache_key_does_not_expose_secret(self):
+        adapter = DynamoDbAdapter()
+        operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
+        secret = "very-secret-value"
+
+        with patch.dict(os.environ, {'AWS_SECRET_ACCESS_KEY': secret, 'AWS_SESSION_TOKEN': ''}):
+            with patch('rococo.data.dynamodb.Connection'):
+                with patch('rococo.data.dynamodb.TransactWrite'):
+                    adapter.run_transaction([operation])
+
+        self.assertNotIn(secret, repr(adapter._connections))
+
+    def test_session_token_connections_are_not_cached(self):
+        adapter = DynamoDbAdapter()
+        operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
+
+        with patch.dict(os.environ, {'AWS_SESSION_TOKEN': 'short-lived-token'}):
+            with patch('rococo.data.dynamodb.Connection') as mock_connection:
+                with patch('rococo.data.dynamodb.TransactWrite'):
+                    adapter.run_transaction([operation])
+                    adapter.run_transaction([operation])
+
+        self.assertEqual(mock_connection.call_count, 2)
+        self.assertEqual(adapter._connections, {})
+
+    def test_dynamo_operation_is_publicly_exported(self):
+        from rococo.data import DynamoOperation as ExportedDynamoOperation
+
+        self.assertIs(ExportedDynamoOperation, DynamoOperation)
 
 
 if __name__ == '__main__':

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -7,7 +7,7 @@ from typing import Type
 from pynamodb.models import Model
 from pynamodb.attributes import UnicodeAttribute, BooleanAttribute
 from pynamodb.exceptions import DoesNotExist, TransactWriteError
-from rococo.data.dynamodb import DynamoDbAdapter, DynamoOperation
+from rococo.data.dynamodb import DynamoDbAdapter, DynamoOperation, DynamoPostCommitVersionMismatch
 from rococo.repositories.dynamodb.dynamodb_repository import DynamoDbRepository
 from rococo.models.versioned_model import VersionedModel, get_uuid_hex
 from rococo.messaging import MessageAdapter
@@ -407,7 +407,7 @@ class TestDynamoDbRepository(unittest.TestCase):
             'version': uuid4().hex,
         }
 
-        with self.assertRaisesRegex(RuntimeError, "requires previous_version"):
+        with self.assertRaisesRegex(RuntimeError, "zero UUID sentinel"):
             self.adapter.get_save_query('person', data, model_cls=Person)
 
     def test_get_save_query_rejects_empty_previous_version_for_versioned_data(self):
@@ -540,8 +540,9 @@ class TestDynamoDbRepository(unittest.TestCase):
                 'version': uuid4().hex,
             }
 
-            with self.assertRaisesRegex(RuntimeError, "write succeeded"):
+            with self.assertRaises(DynamoPostCommitVersionMismatch) as context:
                 self.repository._read_committed_state(entity_id, expected_version=expected_version)
+            self.assertIn("write succeeded", str(context.exception))
 
     def test_session_token_connections_are_not_cached(self):
         adapter = DynamoDbAdapter()
@@ -560,6 +561,61 @@ class TestDynamoDbRepository(unittest.TestCase):
         from rococo.data import DynamoOperation as ExportedDynamoOperation
 
         self.assertIs(ExportedDynamoOperation, DynamoOperation)
+
+    def test_post_commit_version_mismatch_is_publicly_exported(self):
+        from rococo.data import DynamoPostCommitVersionMismatch as Exported
+
+        self.assertIs(Exported, DynamoPostCommitVersionMismatch)
+
+    def test_save_rejects_versioned_data(self):
+        data = {
+            'entity_id': uuid4().hex,
+            'version': uuid4().hex,
+            'previous_version': uuid4().hex,
+            'first_name': 'Jane',
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "must not be used for versioned models"):
+            self.adapter.save('person', data, model_cls=Person)
+
+    def test_save_allows_non_versioned_data(self):
+        data = {
+            'entity_id': uuid4().hex,
+            'first_name': 'Jane',
+        }
+
+        with patch.object(PersonModel, 'save') as mock_save:
+            result = self.adapter.save('person', data, model_cls=Person)
+
+        self.assertIsNotNone(result)
+        mock_save.assert_called_once()
+
+    def test_run_transaction_derives_connection_from_save_op(self):
+        """Connection should be derived from the first save/delete op, not ops[0] if it's audit_save."""
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+
+        audit_op = self.adapter.get_move_entity_to_audit_table_query(
+            'person', entity_id, model_cls=Person, expected_version=old_version
+        )
+        save_op = DynamoOperation("save", PersonModel(entity_id=entity_id))
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            mock_item = MagicMock()
+            mock_item.attribute_values = {'entity_id': entity_id, 'version': old_version}
+            mock_get.return_value = mock_item
+
+            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+                mock_tx = MagicMock()
+                mock_transact_write.return_value.__enter__.return_value = mock_tx
+
+                with patch.object(self.adapter, '_get_connection') as mock_get_conn:
+                    mock_get_conn.return_value = MagicMock()
+                    self.adapter.run_transaction([audit_op, save_op])
+
+                # Connection should be derived from save_op.model (the PersonModel instance)
+                called_with = mock_get_conn.call_args[0][0]
+                self.assertIsInstance(called_with, PersonModel)
 
 
 if __name__ == '__main__':

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -6,9 +6,10 @@ from unittest.mock import MagicMock, patch, ANY
 from typing import Type
 from pynamodb.models import Model
 from pynamodb.attributes import UnicodeAttribute, BooleanAttribute
-from rococo.data.dynamodb import DynamoDbAdapter
+from pynamodb.exceptions import TransactWriteError
+from rococo.data.dynamodb import DynamoDbAdapter, DynamoOperation
 from rococo.repositories.dynamodb.dynamodb_repository import DynamoDbRepository
-from rococo.models.versioned_model import VersionedModel
+from rococo.models.versioned_model import VersionedModel, get_uuid_hex
 from rococo.messaging import MessageAdapter
 
 # Dummy PynamoDB Models
@@ -56,6 +57,15 @@ class PersonAuditModel(Model):
 
     def save(self):
         pass
+
+class NoVersionModel:
+    class Meta:
+        table_name = 'person'
+        region = 'us-east-1'
+    entity_id = UnicodeAttribute(hash_key=True)
+
+    def __init__(self, **kwargs):
+        self.attribute_values = kwargs
 
 # Dummy Rococo Model
 @dataclass
@@ -151,6 +161,9 @@ class TestDynamoDbRepository(unittest.TestCase):
 
             self.assertEqual(saved_person.first_name, 'Jane')
             mock_tx.save.assert_called()
+            condition = mock_tx.save.call_args.kwargs["condition"]
+            self.assertIn("attribute_not_exists", str(condition))
+            self.assertIn("entity_id", str(condition))
             
             # Verify message was sent
             self.message_adapter.send_message.assert_called_with(
@@ -180,10 +193,15 @@ class TestDynamoDbRepository(unittest.TestCase):
                 self.repository.save(person, send_message=True)
 
                 # Ensure we tried to fetch the old record to audit it
-                mock_get.assert_called_with(entity_id)
+                mock_get.assert_called_with(entity_id, consistent_read=True)
 
                 # Ensure we called transaction.save twice (audit + new)
                 self.assertEqual(mock_tx.save.call_count, 2)
+                audit_condition = mock_tx.save.call_args_list[0].kwargs["condition"]
+                save_condition = mock_tx.save.call_args_list[1].kwargs["condition"]
+                self.assertIn("attribute_not_exists", str(audit_condition))
+                self.assertIn("version", str(audit_condition))
+                self.assertIn(old_version, str(save_condition))
 
                 # Verify message was sent
                 self.message_adapter.send_message.assert_called()
@@ -198,6 +216,61 @@ class TestDynamoDbRepository(unittest.TestCase):
 
             self.repository.delete(person)
             mock_tx.save.assert_called()
+
+    def test_get_save_query_uses_shared_zero_uuid_sentinel(self):
+        data = {
+            'entity_id': uuid4().hex,
+            'previous_version': get_uuid_hex(0),
+            'version': uuid4().hex,
+            'active': True,
+        }
+
+        operation = self.adapter.get_save_query('person', data, model_cls=Person)
+
+        self.assertIn("attribute_not_exists", str(operation.condition))
+        self.assertIn("entity_id", str(operation.condition))
+
+    def test_get_save_query_requires_version_attribute_for_updates(self):
+        data = {
+            'entity_id': uuid4().hex,
+            'previous_version': uuid4().hex,
+            'version': uuid4().hex,
+        }
+
+        with patch.object(self.adapter, '_generate_pynamo_model', return_value=NoVersionModel):
+            with self.assertRaisesRegex(RuntimeError, "requires a PynamoDB 'version' attribute"):
+                self.adapter.get_save_query('person', data, model_cls=Person)
+
+    def test_run_transaction_reraises_transact_write_error(self):
+        operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
+        error = TransactWriteError("conditional check failed")
+
+        with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+            mock_transact_write.return_value.__enter__.side_effect = error
+
+            with self.assertRaises(TransactWriteError) as context:
+                self.adapter.run_transaction([operation])
+
+        self.assertIs(context.exception, error)
+
+    def test_run_transaction_validates_operations_before_opening_transaction(self):
+        valid_operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
+
+        with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+            with self.assertRaisesRegex(RuntimeError, "expects only DynamoOperation objects"):
+                self.adapter.run_transaction([valid_operation, object()])
+
+        mock_transact_write.assert_not_called()
+
+    def test_run_transaction_reuses_cached_connection(self):
+        operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
+
+        with patch('rococo.data.dynamodb.Connection') as mock_connection:
+            with patch('rococo.data.dynamodb.TransactWrite'):
+                self.adapter.run_transaction([operation])
+                self.adapter.run_transaction([operation])
+
+        self.assertEqual(mock_connection.call_count, 1)
 
 
 if __name__ == '__main__':

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock, patch, ANY
 from typing import Type
 from pynamodb.models import Model
 from pynamodb.attributes import UnicodeAttribute, BooleanAttribute
-from pynamodb.exceptions import TransactWriteError
+from pynamodb.exceptions import DoesNotExist, TransactWriteError
 from rococo.data.dynamodb import DynamoDbAdapter, DynamoOperation
 from rococo.repositories.dynamodb.dynamodb_repository import DynamoDbRepository
 from rococo.models.versioned_model import VersionedModel, get_uuid_hex
@@ -276,7 +276,7 @@ class TestDynamoDbRepository(unittest.TestCase):
         self.assertEqual(operation.entity_id, entity_id)
         self.assertEqual(operation.expected_version, old_version)
 
-    def test_audit_operation_rejects_snapshot_version_mismatch(self):
+    def test_audit_operation_defers_snapshot_version_mismatch_to_transaction_condition(self):
         entity_id = uuid4().hex
         old_version = uuid4().hex
         operation = self.adapter.get_move_entity_to_audit_table_query(
@@ -298,9 +298,30 @@ class TestDynamoDbRepository(unittest.TestCase):
                 mock_tx = MagicMock()
                 mock_transact_write.return_value.__enter__.return_value = mock_tx
 
-                with self.assertRaisesRegex(RuntimeError, "audit snapshot version mismatch"):
+                self.adapter.run_transaction([operation])
+
+        mock_tx.condition_check.assert_called_once()
+        self.assertIn(old_version, str(mock_tx.condition_check.call_args.kwargs["condition"]))
+        mock_tx.save.assert_called_once()
+
+    def test_audit_operation_rejects_missing_source_item(self):
+        entity_id = uuid4().hex
+        operation = self.adapter.get_move_entity_to_audit_table_query(
+            'person',
+            entity_id,
+            model_cls=Person,
+            expected_version=uuid4().hex
+        )
+
+        with patch.object(PersonModel, 'get', side_effect=DoesNotExist()):
+            with patch('rococo.data.dynamodb.TransactWrite') as mock_transact_write:
+                mock_tx = MagicMock()
+                mock_transact_write.return_value.__enter__.return_value = mock_tx
+
+                with self.assertRaisesRegex(RuntimeError, "does not exist"):
                     self.adapter.run_transaction([operation])
 
+        mock_tx.condition_check.assert_not_called()
         mock_tx.save.assert_not_called()
 
     def test_audit_operation_rejects_empty_expected_version(self):
@@ -447,6 +468,7 @@ class TestDynamoDbRepository(unittest.TestCase):
         adapter = DynamoDbAdapter()
         operation = DynamoOperation("save", PersonModel(entity_id=uuid4().hex))
 
+        # Empty string simulates no temporary session token.
         with patch.dict(os.environ, {'AWS_SESSION_TOKEN': ''}):
             with patch('rococo.data.dynamodb.Connection') as mock_connection:
                 with patch('rococo.data.dynamodb.TransactWrite'):
@@ -467,9 +489,19 @@ class TestDynamoDbRepository(unittest.TestCase):
 
         self.assertNotIn(secret, repr(adapter._connections))
 
+    def test_model_and_connection_cache_keys_use_separate_namespaces(self):
+        adapter = DynamoDbAdapter()
+        args = ("us-east-1", None, "testing", "secret")
+
+        self.assertNotEqual(
+            adapter._model_cache_digest(*args),
+            adapter._connection_cache_key(*args)
+        )
+
     def test_generated_pynamo_model_is_cached_without_session_token(self):
         adapter = DynamoDbAdapter()
 
+        # Empty string simulates no temporary session token.
         with patch.dict(os.environ, {'AWS_SESSION_TOKEN': ''}):
             first_model = adapter._generate_pynamo_model('person', Person)
             second_model = adapter._generate_pynamo_model('person', Person)
@@ -508,7 +540,7 @@ class TestDynamoDbRepository(unittest.TestCase):
                 'version': uuid4().hex,
             }
 
-            with self.assertRaisesRegex(RuntimeError, "read back version"):
+            with self.assertRaisesRegex(RuntimeError, "write succeeded"):
                 self.repository._read_committed_state(entity_id, expected_version=expected_version)
 
     def test_session_token_connections_are_not_cached(self):


### PR DESCRIPTION
# Describe your changes

- Implement DynamoDB ACID writes using PynamoDB TransactWrite so audit + main write are atomic for VersionedModel.
- Make run_transaction strict (accepts only DynamoOperation, no legacy callables).
- Update DynamoDbRepository to use run_transaction for save/delete flows.
- Fix create vs update conditional logic (treat zero previous_version as create).
- Update DynamoDB docs and adjust unit tests to mock TransactWrite.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)
