### PR TITLE
Extract SQLMigrationBase, validate identifiers, fix runner recursion

### DIFF
--- a/rococo/migrations/common/migration_runner.py
+++ b/rococo/migrations/common/migration_runner.py
@@ -1,10 +1,8 @@
 import os
 import logging
+import importlib
 from importlib import import_module
-# Assuming migration_template.py is in the same directory or accessible in python path
-# For a common module, it would typically be:
-# from rococo.migrations.common.migration_template import get_template
-from .migration_template import get_template # This relative import is fine if it's part of a package
+from .migration_template import get_template
 
 class MigrationRunner:
     def __init__(self, migrations_dir, migration):
@@ -150,42 +148,40 @@ class MigrationRunner:
             print(f"Error creating migration file: {e}")
 
     def run_forward_migration_script(self, initial_db_version_for_run):
-        # Renamed old_db_version to initial_db_version_for_run for clarity
-        current_script_filename = self._get_forward_migration_script()
+        # Iterates one migration at a time, re-resolving the next forward script
+        # against the DB version updated by the just-applied script. Iterative to
+        # avoid stack overflow on deep migration histories.
+        while True:
+            current_script_filename = self._get_forward_migration_script()
 
-        if current_script_filename is None:
-            latest_db_version_after_ops = self.get_db_version()
-            if initial_db_version_for_run == latest_db_version_after_ops:
-                # This means no scripts were found that could run from initial_db_version_for_run
-                logging.info(f'No forward migration scripts found for current DB version: {initial_db_version_for_run}. Database is likely up to date.')
-            else:
-                # This means some migrations ran, and now no more are found.
-                logging.info('All pending forward migrations complete!')
-            logging.info(f'Latest DB version: {latest_db_version_after_ops}')
-            return # End of migration run
+            if current_script_filename is None:
+                latest_db_version_after_ops = self.get_db_version()
+                if initial_db_version_for_run == latest_db_version_after_ops:
+                    logging.info(
+                        f'No forward migration scripts found for current DB version: '
+                        f'{initial_db_version_for_run}. Database is likely up to date.'
+                    )
+                else:
+                    logging.info('All pending forward migrations complete!')
+                logging.info(f'Latest DB version: {latest_db_version_after_ops}')
+                return
 
-        # Using os.path.basename to be platform-agnostic, though split('/') works on POSIX
-        logging.info(f'Running forward migration: {os.path.basename(current_script_filename)}.py')
-        
-        try:
-            # Dynamically import the migration module
-            # Assumes migrations_dir is in sys.path (BaseCli handles this)            
-            module_name = current_script_filename
-            migration_module = import_module(module_name) # Assumes migrations_dir is in sys.path
-            migration_module.upgrade(self.migration)
-        except Exception as e:
-            logging.error(f"Error during forward migration {current_script_filename}.py: {e}", exc_info=True)
-            # This print is for direct CLI feedback during a run
-            print(f"Error applying migration {current_script_filename}.py. Halting.")
-            # Potentially offer to show current DB version or suggest manual check
-            print(f"Current DB version after error: {self.get_db_version()}")
-            return # Stop further migrations
+            logging.info(
+                f'Running forward migration: {os.path.basename(current_script_filename)}.py'
+            )
 
-        # Recursively run next forward migration
-        # The `initial_db_version_for_run` remains the version from the start of this `rf` command.
-        # The next call to `_get_forward_migration_script` will use the *new* current DB version
-        # (updated by the migration script that just ran).
-        return self.run_forward_migration_script(initial_db_version_for_run)
+            try:
+                importlib.invalidate_caches()
+                migration_module = import_module(current_script_filename)
+                migration_module.upgrade(self.migration)
+            except Exception as e:
+                logging.error(
+                    f"Error during forward migration {current_script_filename}.py: {e}",
+                    exc_info=True,
+                )
+                print(f"Error applying migration {current_script_filename}.py. Halting.")
+                print(f"Current DB version after error: {self.get_db_version()}")
+                return
 
     def run_backward_migration_script(self):
         current_script_filename = self._get_backward_migration_script()
@@ -197,8 +193,8 @@ class MigrationRunner:
         logging.info(f'Running backward migration: {os.path.basename(current_script_filename)}.py')
         
         try:
-            module_name = current_script_filename
-            migration_module = import_module(module_name)
+            importlib.invalidate_caches()
+            migration_module = import_module(current_script_filename)
             migration_module.downgrade(self.migration)
         except Exception as e:
             logging.error(f"Error during backward migration {current_script_filename}.py: {e}", exc_info=True)

--- a/rococo/migrations/common/sql_migration_base.py
+++ b/rococo/migrations/common/sql_migration_base.py
@@ -1,0 +1,215 @@
+import logging
+import re
+from typing import Any, Iterable, Optional
+
+from .migration_base import MigrationBase
+
+
+class SQLMigrationBase(MigrationBase):
+    """Shared SQL migration helpers for relational adapters.
+
+    Concrete subclasses (e.g. PostgresMigration, MySQLMigration) provide the
+    dialect-specific SQL via class-level templates and queries. Identifiers
+    (table, column, index, constraint names) are validated against
+    ``_IDENT_RE`` before being interpolated into SQL. Values (database name,
+    version strings) are bound through the adapter's parameterized query
+    interface, never concatenated into SQL strings.
+    """
+
+    # Parameterized queries (use %s placeholders).
+    EXISTS_COLUMN_QUERY: str = NotImplemented      # args: (database, table, column)
+    EXISTS_PK_QUERY: str = NotImplemented          # args: (database, table)
+    UPDATE_VERSION_QUERY: str = NotImplemented     # args: (version,)
+    INSERT_DB_VERSION_DATA_QUERY: str = NotImplemented  # no args
+
+    # Identifier templates (use str.format with validated names).
+    DROP_PK_TEMPLATE: str = NotImplemented         # {table}
+    ADD_PK_TEMPLATE: str = NotImplemented          # {table}, {keys}
+    ADD_COLUMN_TEMPLATE: str = NotImplemented      # {table}, {column}, {datatype}
+    DROP_COLUMN_TEMPLATE: str = NotImplemented     # {table}, {column}
+    ADD_INDEX_TEMPLATE: str = NotImplemented       # {table}, {index}, {column}
+    REMOVE_INDEX_TEMPLATE: str = NotImplemented    # {table}, {index}
+    ALTER_INDEX_TEMPLATES: tuple = NotImplemented  # tuple of templates run in order
+    ALTER_COLUMN_TEMPLATE: str = NotImplemented    # {table}, {column}, {datatype}
+    RENAME_COLUMN_TEMPLATE: str = NotImplemented   # {table}, {old}, {new}
+    RENAME_TABLE_TEMPLATE: str = NotImplemented    # {old_table}, {new_table}
+    CREATE_TABLE_TEMPLATE: str = NotImplemented    # {table}, {fields_with_type}
+    DROP_TABLE_IF_EXISTS_TEMPLATE: str = NotImplemented  # {table}
+    DROP_TABLE_TEMPLATE: str = NotImplemented      # {table}
+
+    _IDENT_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+    def _validate_ident(self, name: str) -> str:
+        if not isinstance(name, str) or not self._IDENT_RE.match(name):
+            raise ValueError(f"invalid SQL identifier: {name!r}")
+        return name
+
+    def _validate_idents(self, names: Iterable[str]) -> None:
+        for n in names:
+            self._validate_ident(n)
+
+    def _validate_pk_keys(self, keys: str) -> str:
+        if not isinstance(keys, str) or not (keys.startswith("(") and keys.endswith(")")):
+            raise ValueError(
+                f"primary key keys must be wrapped in parentheses, got: {keys!r}"
+            )
+        inner = keys[1:-1]
+        for col in inner.split(","):
+            self._validate_ident(col.strip())
+        return keys
+
+    @staticmethod
+    def _extract_count(response: Any) -> int:
+        if not response:
+            return 0
+        row = response[0] if isinstance(response, list) else response
+        if not isinstance(row, dict) or not row:
+            return 0
+        value = next(iter(row.values()))
+        return int(value or 0)
+
+    def _does_column_exist(self, table_name, column_name, commit: bool = True) -> bool:
+        self._validate_idents([table_name, column_name])
+        rows = self.execute(
+            self.EXISTS_COLUMN_QUERY,
+            commit=commit,
+            args=(self.db_adapter._database, table_name, column_name),
+        )
+        return self._extract_count(rows) > 0
+
+    def _does_primary_key_constraint_exists(self, table_name, commit: bool = True) -> bool:
+        self._validate_ident(table_name)
+        rows = self.execute(
+            self.EXISTS_PK_QUERY,
+            commit=commit,
+            args=(self.db_adapter._database, table_name),
+        )
+        return self._extract_count(rows) > 0
+
+    def remove_primary_key(self, table_name, commit: bool = True):
+        self._validate_ident(table_name)
+        if self._does_primary_key_constraint_exists(table_name, commit=commit):
+            return self.execute(
+                self.DROP_PK_TEMPLATE.format(table=table_name), commit=commit
+            )
+        logging.info(
+            f"PRIMARY KEY constraint for table {table_name} does not exist. "
+            f"Skipping removal..."
+        )
+
+    def add_primary_key(self, table_name, keys: str, commit: bool = True):
+        self._validate_ident(table_name)
+        self._validate_pk_keys(keys)
+        if self._does_primary_key_constraint_exists(table_name, commit=commit):
+            self.execute(
+                self.DROP_PK_TEMPLATE.format(table=table_name), commit=commit
+            )
+        return self.execute(
+            self.ADD_PK_TEMPLATE.format(table=table_name, keys=keys), commit=commit
+        )
+
+    def add_column(self, table_name, column_name, datatype, commit: bool = True):
+        self._validate_idents([table_name, column_name])
+        if self._does_column_exist(table_name, column_name, commit=commit):
+            logging.info(
+                f"Column {column_name} for table {table_name} already exists. "
+                f"Skipping creation..."
+            )
+            return
+        query = self.ADD_COLUMN_TEMPLATE.format(
+            table=table_name, column=column_name, datatype=datatype
+        )
+        self.execute(query, commit=commit)
+
+    def drop_column(self, table_name, column_name, commit: bool = True):
+        self._validate_idents([table_name, column_name])
+        if not self._does_column_exist(table_name, column_name, commit=commit):
+            logging.info(
+                f"Column {column_name} for table {table_name} does not exist. "
+                f"Skipping deletion..."
+            )
+            return
+        query = self.DROP_COLUMN_TEMPLATE.format(
+            table=table_name, column=column_name
+        )
+        self.execute(query, commit=commit)
+
+    def alter_index(
+        self,
+        table_name,
+        new_index_name,
+        new_indexed_column,
+        old_index_name,
+        commit: bool = True,
+    ):
+        self._validate_idents(
+            [table_name, new_index_name, new_indexed_column, old_index_name]
+        )
+        for tmpl in self.ALTER_INDEX_TEMPLATES:
+            query = tmpl.format(
+                table=table_name,
+                new_index=new_index_name,
+                new_column=new_indexed_column,
+                old_index=old_index_name,
+            )
+            self.execute(query, commit=commit)
+
+    def add_index(self, table_name, index_name, indexed_column, commit: bool = True):
+        self._validate_idents([table_name, index_name, indexed_column])
+        query = self.ADD_INDEX_TEMPLATE.format(
+            table=table_name, index=index_name, column=indexed_column
+        )
+        self.execute(query, commit=commit)
+
+    def remove_index(self, table_name, index_name, commit: bool = True):
+        self._validate_idents([table_name, index_name])
+        query = self.REMOVE_INDEX_TEMPLATE.format(
+            table=table_name, index=index_name
+        )
+        self.execute(query, commit=commit)
+
+    def alter_column(self, table_name, column_name, datatype, commit: bool = True):
+        self._validate_idents([table_name, column_name])
+        query = self.ALTER_COLUMN_TEMPLATE.format(
+            table=table_name, column=column_name, datatype=datatype
+        )
+        self.execute(query, commit=commit)
+
+    def change_column_name(
+        self, table_name, old_column_name, new_column_name, commit: bool = True
+    ):
+        self._validate_idents([table_name, old_column_name, new_column_name])
+        query = self.RENAME_COLUMN_TEMPLATE.format(
+            table=table_name, old=old_column_name, new=new_column_name
+        )
+        self.execute(query, commit=commit)
+
+    def change_table_name(self, old_table, new_table, commit: bool = True):
+        self._validate_idents([old_table, new_table])
+        query = self.RENAME_TABLE_TEMPLATE.format(
+            old_table=old_table, new_table=new_table
+        )
+        self.execute(query, commit=commit)
+
+    def create_table(
+        self, table_name, fields_with_type, drop_if_exists: bool = True, commit: bool = True
+    ):
+        self._validate_ident(table_name)
+        if drop_if_exists:
+            drop_query = self.DROP_TABLE_IF_EXISTS_TEMPLATE.format(table=table_name)
+            self.execute(drop_query, commit=commit)
+        create_query = self.CREATE_TABLE_TEMPLATE.format(
+            table=table_name, fields_with_type=fields_with_type
+        )
+        self.execute(create_query, commit=commit)
+
+    def drop_table(self, table_name, commit: bool = True):
+        self._validate_ident(table_name)
+        query = self.DROP_TABLE_TEMPLATE.format(table=table_name)
+        self.execute(query, commit=commit)
+
+    def insert_db_version_data(self, commit: bool = True):
+        self.execute(self.INSERT_DB_VERSION_DATA_QUERY, commit=commit)
+
+    def update_version_table(self, version, commit: bool = True):
+        self.execute(self.UPDATE_VERSION_QUERY, commit=commit, args=(str(version),))

--- a/rococo/migrations/mysql/migration.py
+++ b/rococo/migrations/mysql/migration.py
@@ -1,112 +1,40 @@
-import logging
-from ..common.migration_base import MigrationBase
+from ..common.sql_migration_base import SQLMigrationBase
 from rococo.data.mysql import MySqlAdapter
 
 
-class MySQLMigration(MigrationBase):
+class MySQLMigration(SQLMigrationBase):
+    EXISTS_COLUMN_QUERY = (
+        "SELECT COUNT(*) AS count "
+        "FROM information_schema.COLUMNS "
+        "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s AND COLUMN_NAME = %s;"
+    )
+    EXISTS_PK_QUERY = (
+        "SELECT COUNT(*) AS count "
+        "FROM information_schema.TABLE_CONSTRAINTS "
+        "WHERE TABLE_SCHEMA = %s AND TABLE_NAME = %s "
+        "AND CONSTRAINT_TYPE = 'PRIMARY KEY';"
+    )
+    UPDATE_VERSION_QUERY = "UPDATE db_version SET version = %s;"
+    INSERT_DB_VERSION_DATA_QUERY = (
+        "INSERT INTO db_version (version) VALUES ('0000000000');"
+    )
+
+    DROP_PK_TEMPLATE = "ALTER TABLE {table} DROP PRIMARY KEY;"
+    ADD_PK_TEMPLATE = "ALTER TABLE {table} ADD PRIMARY KEY {keys};"
+    ADD_COLUMN_TEMPLATE = "ALTER TABLE {table} ADD {column} {datatype};"
+    DROP_COLUMN_TEMPLATE = "ALTER TABLE {table} DROP {column};"
+    ADD_INDEX_TEMPLATE = "ALTER TABLE {table} ADD INDEX {index} ({column});"
+    REMOVE_INDEX_TEMPLATE = "ALTER TABLE {table} DROP INDEX {index};"
+    ALTER_INDEX_TEMPLATES = (
+        "ALTER TABLE {table} ADD INDEX {new_index} ({new_column}), "
+        "DROP INDEX {old_index};",
+    )
+    ALTER_COLUMN_TEMPLATE = "ALTER TABLE {table} MODIFY COLUMN {column} {datatype};"
+    RENAME_COLUMN_TEMPLATE = "ALTER TABLE {table} RENAME COLUMN {old} TO {new};"
+    RENAME_TABLE_TEMPLATE = "ALTER TABLE {old_table} RENAME TO {new_table};"
+    CREATE_TABLE_TEMPLATE = "CREATE TABLE {table} ({fields_with_type});"
+    DROP_TABLE_IF_EXISTS_TEMPLATE = "DROP TABLE IF EXISTS {table};"
+    DROP_TABLE_TEMPLATE = "DROP TABLE {table};"
+
     def __init__(self, db_adapter: MySqlAdapter):
         super().__init__(db_adapter)
-
-    def _does_column_exist(self, table_name, column_name, commit: bool = True):
-        schema_name = self.db_adapter._database
-        query = f"""
-        SELECT COUNT(*) 
-            FROM information_schema.COLUMNS 
-            WHERE 
-                TABLE_SCHEMA = '{schema_name}' 
-            AND TABLE_NAME = '{table_name}' 
-            AND COLUMN_NAME = '{column_name}';
-        """
-        response = self.execute(query, commit=commit)
-        return response[0].get("COUNT(*)") > 0
-
-    def _does_primary_key_constraint_exists(self, table_name, commit: bool = True):
-        schema_name = self.db_adapter._database
-        query = f"""
-        SELECT COUNT(*) 
-            FROM information_schema.TABLE_CONSTRAINTS 
-            WHERE 
-                TABLE_SCHEMA = '{schema_name}' 
-            AND TABLE_NAME = '{table_name}' 
-            AND CONSTRAINT_TYPE = 'PRIMARY KEY';
-        """
-        response = self.execute(query, commit=commit)
-        return response[0].get("COUNT(*)") > 0
-
-    def remove_primary_key(self, table_name, commit: bool = True):
-        if self._does_primary_key_constraint_exists(table_name, commit=commit):
-            query = f"""ALTER TABLE {table_name} DROP PRIMARY KEY;"""
-            return self.execute(query, commit)
-
-        logging.info(
-            f"PRIMARY KEY constraints for table {table_name} does not exist. Skipping remove primary key..."
-        )
-
-    def add_primary_key(self, table_name, keys: str, commit: bool = True):
-        if self._does_primary_key_constraint_exists(table_name, commit=commit):
-            query = f"""ALTER TABLE {table_name} DROP PRIMARY KEY;"""
-            self.execute(query, commit)
-
-        query = f"""ALTER TABLE {table_name} ADD PRIMARY KEY {keys};"""
-        return self.execute(query, commit)
-
-    def add_column(self, table_name, column_name, datatype, commit: bool = True):
-        if self._does_column_exist(table_name, column_name, commit=commit):
-            logging.info(f"Column {column_name} for table {table_name} already exists. Skipping creation...")
-            return
-        query = f"""ALTER TABLE {table_name} ADD {column_name} {datatype};"""
-        self.execute(query, commit)
-
-    def drop_column(self, table_name, column_name, commit: bool = True):
-        if not self._does_column_exist(table_name, column_name, commit=commit):
-            logging.info(f"Column {column_name} for table {table_name} does not exist. Skipping deletion...")
-            return
-        query = f"""ALTER TABLE {table_name} DROP {column_name};"""
-        self.execute(query, commit=commit)
-
-    def alter_index(self, table_name, new_index_name, new_indexed_column, old_index_name, commit: bool = True):
-        query = f"""ALTER TABLE {table_name} ADD INDEX {new_index_name} ({new_indexed_column}), DROP INDEX {old_index_name};"""
-        self.execute(query, commit=commit)
-
-    def add_index(self, table_name, index_name, indexed_column, commit: bool = True):
-        query = f"""ALTER TABLE {table_name} ADD INDEX {index_name} ({indexed_column});"""
-        self.execute(query, commit=commit)
-
-    def remove_index(self, table_name, index_name, commit: bool = True):
-        query = f"""ALTER TABLE {table_name} DROP INDEX {index_name};"""
-        self.execute(query, commit=commit)
-
-    def alter_column(self, table_name, column_name, datatype, commit: bool = True):
-        query = f"""ALTER TABLE {table_name} MODIFY COLUMN {column_name} {datatype};"""
-        self.execute(query, commit=commit)
-
-    def change_column_name(self, table_name, old_column_name, new_column_name, commit: bool = True):
-        query = f"""ALTER TABLE {table_name} RENAME COLUMN {old_column_name} TO {new_column_name};"""
-        self.execute(query, commit=commit)
-
-    def change_table_name(self, old_table, new_table, commit: bool = True):
-        query = f"""ALTER TABLE {old_table} RENAME TO {new_table};"""
-        self.execute(query, commit=commit)
-
-    def create_table(self, table_name, fields_with_type, drop_if_exists=True, commit: bool = True):
-        if drop_if_exists:
-            drop_query = f"""DROP TABLE IF EXISTS {table_name};"""
-            self.execute(drop_query, commit=commit)
-        create_query = f"""CREATE TABLE {table_name} ({fields_with_type});"""
-        self.execute(create_query, commit=commit)
-
-    def drop_table(self, table_name, commit: bool = True):
-        query = f"""DROP TABLE {table_name};"""
-        self.execute(query, commit=commit)
-
-    def insert_db_version_data(self, commit: bool = True):
-        query = f"INSERT INTO db_version (version) VALUES (0000000000);"
-        self.execute(query, commit=commit)
-
-    def update_version_table(self, version, commit: bool = True):
-        query = f"UPDATE db_version SET version = {version};"
-        self.execute(query, commit=commit)
-
-    @staticmethod
-    def _cursor_to_dict(result, description):
-        return dict(zip([col[0] for col in description], result))

--- a/rococo/migrations/postgres/migration.py
+++ b/rococo/migrations/postgres/migration.py
@@ -1,111 +1,44 @@
-import logging
-from ..common.migration_base import MigrationBase
+from ..common.sql_migration_base import SQLMigrationBase
 from rococo.data.postgresql import PostgreSQLAdapter
 
-class PostgresMigration(MigrationBase):
+
+class PostgresMigration(SQLMigrationBase):
+    EXISTS_COLUMN_QUERY = (
+        "SELECT COUNT(*) AS count "
+        "FROM information_schema.columns "
+        "WHERE table_catalog = %s AND table_name = %s AND column_name = %s;"
+    )
+    EXISTS_PK_QUERY = (
+        "SELECT COUNT(*) AS count "
+        "FROM information_schema.table_constraints "
+        "WHERE table_catalog = %s AND table_name = %s "
+        "AND constraint_type = 'PRIMARY KEY';"
+    )
+    UPDATE_VERSION_QUERY = "UPDATE db_version SET version = %s;"
+    INSERT_DB_VERSION_DATA_QUERY = (
+        "INSERT INTO db_version (version) VALUES ('0000000000');"
+    )
+
+    DROP_PK_TEMPLATE = (
+        "ALTER TABLE {table} DROP CONSTRAINT IF EXISTS {table}_pkey;"
+    )
+    ADD_PK_TEMPLATE = (
+        "ALTER TABLE {table} ADD CONSTRAINT {table}_pkey PRIMARY KEY {keys};"
+    )
+    ADD_COLUMN_TEMPLATE = "ALTER TABLE {table} ADD COLUMN {column} {datatype};"
+    DROP_COLUMN_TEMPLATE = "ALTER TABLE {table} DROP COLUMN {column};"
+    ADD_INDEX_TEMPLATE = "CREATE INDEX {index} ON {table} ({column});"
+    REMOVE_INDEX_TEMPLATE = "DROP INDEX IF EXISTS {index};"
+    ALTER_INDEX_TEMPLATES = (
+        "DROP INDEX IF EXISTS {old_index};",
+        "CREATE INDEX {new_index} ON {table} ({new_column});",
+    )
+    ALTER_COLUMN_TEMPLATE = "ALTER TABLE {table} ALTER COLUMN {column} TYPE {datatype};"
+    RENAME_COLUMN_TEMPLATE = "ALTER TABLE {table} RENAME COLUMN {old} TO {new};"
+    RENAME_TABLE_TEMPLATE = "ALTER TABLE {old_table} RENAME TO {new_table};"
+    CREATE_TABLE_TEMPLATE = "CREATE TABLE {table} ({fields_with_type});"
+    DROP_TABLE_IF_EXISTS_TEMPLATE = "DROP TABLE IF EXISTS {table} CASCADE;"
+    DROP_TABLE_TEMPLATE = "DROP TABLE {table} CASCADE;"
+
     def __init__(self, db_adapter: PostgreSQLAdapter):
         super().__init__(db_adapter)
-
-    def _does_column_exist(self, table_name, column_name, commit: bool = True):
-        table_catalog = self.db_adapter._database
-
-        query = f"""
-        SELECT COUNT(*) 
-        FROM information_schema.columns 
-        WHERE table_catalog = '{table_catalog}'
-          AND table_name = '{table_name}'
-          AND column_name = '{column_name}';
-        """
-        response = self.execute(query, commit=commit)
-        return int(response[0].get("count", 0)) > 0
-
-    def _does_primary_key_constraint_exists(self, table_name, commit: bool = True):
-        table_catalog = self.db_adapter._database
-
-        query = f"""
-        SELECT COUNT(*) 
-        FROM information_schema.table_constraints 
-        WHERE table_catalog = '{table_catalog}'
-          AND table_name = '{table_name}'
-          AND constraint_type = 'PRIMARY KEY';
-        """
-        response = self.execute(query, commit=commit)
-        return int(response[0].get("count", 0)) > 0
-
-    def remove_primary_key(self, table_name, commit: bool = True):
-        if self._does_primary_key_constraint_exists(table_name, commit=commit):
-            # Assuming the primary key constraint follows the convention: <table_name>_pkey
-            query = f"ALTER TABLE {table_name} DROP CONSTRAINT IF EXISTS {table_name}_pkey;"
-            return self.execute(query, commit=commit)
-        logging.info(
-            f"PRIMARY KEY constraint for table {table_name} does not exist. Skipping removal..."
-        )
-
-    def add_primary_key(self, table_name, keys: str, commit: bool = True):
-        if self._does_primary_key_constraint_exists(table_name, commit=commit):
-            query = f"ALTER TABLE {table_name} DROP CONSTRAINT IF EXISTS {table_name}_pkey;"
-            self.execute(query, commit=commit)
-        # 'keys' should be provided as a string like "(column1, column2)"
-        query = f"ALTER TABLE {table_name} ADD CONSTRAINT {table_name}_pkey PRIMARY KEY {keys};"
-        return self.execute(query, commit=commit)
-
-    def add_column(self, table_name, column_name, datatype, commit: bool = True):
-        if self._does_column_exist(table_name, column_name, commit=commit):
-            logging.info(f"Column {column_name} for table {table_name} already exists. Skipping creation...")
-            return
-        query = f"ALTER TABLE {table_name} ADD COLUMN {column_name} {datatype};"
-        self.execute(query, commit=commit)
-
-    def drop_column(self, table_name, column_name, commit: bool = True):
-        if not self._does_column_exist(table_name, column_name, commit=commit):
-            logging.info(f"Column {column_name} for table {table_name} does not exist. Skipping deletion...")
-            return
-        query = f"ALTER TABLE {table_name} DROP COLUMN {column_name};"
-        self.execute(query, commit=commit)
-
-    def alter_index(self, table_name, new_index_name, new_indexed_column, old_index_name, commit: bool = True):
-        # PostgreSQL requires separate operations for dropping and creating indexes.
-        drop_query = f"DROP INDEX IF EXISTS {old_index_name};"
-        self.execute(drop_query, commit=commit)
-        create_query = f"CREATE INDEX {new_index_name} ON {table_name} ({new_indexed_column});"
-        self.execute(create_query, commit=commit)
-
-    def add_index(self, table_name, index_name, indexed_column, commit: bool = True):
-        query = f"CREATE INDEX {index_name} ON {table_name} ({indexed_column});"
-        self.execute(query, commit=commit)
-
-    def remove_index(self, table_name, index_name, commit: bool = True):
-        query = f"DROP INDEX IF EXISTS {index_name};"
-        self.execute(query, commit=commit)
-
-    def alter_column(self, table_name, column_name, datatype, commit: bool = True):
-        query = f"ALTER TABLE {table_name} ALTER COLUMN {column_name} TYPE {datatype};"
-        self.execute(query, commit=commit)
-
-    def change_column_name(self, table_name, old_column_name, new_column_name, commit: bool = True):
-        query = f"ALTER TABLE {table_name} RENAME COLUMN {old_column_name} TO {new_column_name};"
-        self.execute(query, commit=commit)
-
-    def change_table_name(self, old_table, new_table, commit: bool = True):
-        query = f"ALTER TABLE {old_table} RENAME TO {new_table};"
-        self.execute(query, commit=commit)
-
-    def create_table(self, table_name, fields_with_type, drop_if_exists=True, commit: bool = True):
-        if drop_if_exists:
-            # Using CASCADE to drop dependent objects, adjust if needed
-            drop_query = f"DROP TABLE IF EXISTS {table_name} CASCADE;"
-            self.execute(drop_query, commit=commit)
-        create_query = f"CREATE TABLE {table_name} ({fields_with_type});"
-        self.execute(create_query, commit=commit)
-
-    def drop_table(self, table_name, commit: bool = True):
-        query = f"DROP TABLE {table_name} CASCADE;"
-        self.execute(query, commit=commit)
-
-    def insert_db_version_data(self, commit: bool = True):
-        query = "INSERT INTO db_version (version) VALUES ('0000000000');"
-        self.execute(query, commit=commit)
-
-    def update_version_table(self, version, commit: bool = True):
-        query = f"UPDATE db_version SET version = '{version}';"
-        self.execute(query, commit=commit)

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.2.1',
+    version='1.3.0',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/migration_cli_base_test.py
+++ b/tests/migration_cli_base_test.py
@@ -1,0 +1,234 @@
+"""Tests for rococo.migrations.common.cli_base.BaseCli.
+
+Covers:
+- load_env: env-vars-only path, --env-files path, .env.secrets path, missing vars
+- get_migrations_dir: explicit path, default fallback, failure
+- run flow: dispatches subcommands to MigrationRunner
+"""
+
+import argparse
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rococo.migrations.common.cli_base import BaseCli
+
+
+class _FakeAdapter:
+    pass
+
+
+class _FakeMigration:
+    def __init__(self, adapter):
+        self.adapter = adapter
+
+
+class _ConcreteCli(BaseCli):
+    DB_TYPE = "test"
+    REQUIRED_ENV_VARS = ["FOO", "BAR"]
+    ADAPTER_CLASS = _FakeAdapter
+    MIGRATION_CLASS = _FakeMigration
+
+    def get_db_adapter(self, merged_env):
+        return _FakeAdapter()
+
+
+def _cli():
+    return _ConcreteCli()
+
+
+# ---------- load_env ----------
+
+class TestLoadEnv:
+    def test_loads_from_environment_when_all_vars_present(self, monkeypatch):
+        monkeypatch.setenv("FOO", "fooval")
+        monkeypatch.setenv("BAR", "barval")
+        cli = _cli()
+        args = argparse.Namespace(env_files=[])
+
+        env = cli.load_env(args)
+
+        assert env == {"FOO": "fooval", "BAR": "barval"}
+
+    def test_loads_from_explicit_env_files(self, monkeypatch, tmp_path):
+        env_file = tmp_path / "test.env"
+        env_file.write_text("FOO=fileval\nBAR=barfile\n")
+        cli = _cli()
+        args = argparse.Namespace(env_files=[str(env_file)])
+
+        env = cli.load_env(args)
+
+        assert env["FOO"] == "fileval"
+        assert env["BAR"] == "barfile"
+
+    def test_explicit_env_file_missing_calls_parser_error(self, tmp_path):
+        cli = _cli()
+        cli.parser = MagicMock()
+        cli.parser.error.side_effect = SystemExit(2)
+        args = argparse.Namespace(env_files=[str(tmp_path / "nonexistent.env")])
+
+        with pytest.raises(SystemExit):
+            cli.load_env(args)
+
+        cli.parser.error.assert_called_once()
+
+    def test_falls_back_to_dot_env_secrets(self, monkeypatch, tmp_path):
+        # Clear required vars so it goes into the .env.secrets fallback
+        monkeypatch.delenv("FOO", raising=False)
+        monkeypatch.delenv("BAR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        (tmp_path / ".env.secrets").write_text("APP_ENV=staging\nFOO=secret\n")
+        (tmp_path / "staging.env").write_text("BAR=barvalue\n")
+
+        cli = _cli()
+        args = argparse.Namespace(env_files=[])
+
+        env = cli.load_env(args)
+        assert env["FOO"] == "secret"
+        assert env["BAR"] == "barvalue"
+
+    def test_missing_dot_env_secrets_calls_parser_error(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("FOO", raising=False)
+        monkeypatch.delenv("BAR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        cli = _cli()
+        cli.parser = MagicMock()
+        cli.parser.error.side_effect = SystemExit(2)
+        args = argparse.Namespace(env_files=[])
+
+        with pytest.raises(SystemExit):
+            cli.load_env(args)
+
+    def test_dot_env_secrets_without_app_env_calls_parser_error(self, monkeypatch, tmp_path):
+        monkeypatch.delenv("FOO", raising=False)
+        monkeypatch.delenv("BAR", raising=False)
+        monkeypatch.chdir(tmp_path)
+
+        # .env.secrets exists but lacks APP_ENV
+        (tmp_path / ".env.secrets").write_text("FOO=val\n")
+
+        cli = _cli()
+        cli.parser = MagicMock()
+        cli.parser.error.side_effect = SystemExit(2)
+        args = argparse.Namespace(env_files=[])
+
+        with pytest.raises(SystemExit):
+            cli.load_env(args)
+
+
+# ---------- get_migrations_dir ----------
+
+class TestGetMigrationsDir:
+    def test_uses_explicit_path_when_valid(self, tmp_path):
+        migrations = tmp_path / "migrations"
+        migrations.mkdir()
+        cli = _cli()
+        args = argparse.Namespace(migrations_dir=str(migrations))
+
+        result = cli.get_migrations_dir(args)
+        assert result == str(migrations)
+
+    def test_falls_back_to_default_locations(self, monkeypatch, tmp_path):
+        # Create one of the default fallback dirs
+        (tmp_path / "app" / "migrations").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+
+        cli = _cli()
+        args = argparse.Namespace(migrations_dir=None)
+
+        result = cli.get_migrations_dir(args)
+        assert result == "app/migrations"
+
+    def test_calls_parser_error_when_nothing_found(self, monkeypatch, tmp_path):
+        monkeypatch.chdir(tmp_path)
+        cli = _cli()
+        cli.parser = MagicMock()
+        cli.parser.error.side_effect = SystemExit(2)
+        args = argparse.Namespace(migrations_dir=None)
+
+        with pytest.raises(SystemExit):
+            cli.get_migrations_dir(args)
+
+    def test_invalid_explicit_path_falls_through_to_defaults(self, monkeypatch, tmp_path):
+        # Create a default fallback so the call succeeds via the fallback path
+        (tmp_path / "flask" / "app" / "migrations").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        cli = _cli()
+        args = argparse.Namespace(migrations_dir="/nonexistent/path")
+
+        result = cli.get_migrations_dir(args)
+        assert result == "flask/app/migrations"
+
+
+# ---------- run flow ----------
+
+class TestRunDispatch:
+    def _run_with_command(self, command, monkeypatch, tmp_path):
+        (tmp_path / "app" / "migrations").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("FOO", "fooval")
+        monkeypatch.setenv("BAR", "barval")
+
+        cli = _cli()
+        # Stub argparse to return our chosen command
+        cli.parser = MagicMock()
+        cli.parser.parse_args.return_value = argparse.Namespace(
+            command=command,
+            env_files=[],
+            migrations_dir=None,
+        )
+
+        with patch(
+            "rococo.migrations.common.migration_runner.MigrationRunner"
+        ) as RunnerClass:
+            runner = RunnerClass.return_value
+            runner.get_db_version.return_value = "0000000003"
+            cli.run()
+            return RunnerClass, runner
+
+    def test_run_dispatches_rf(self, monkeypatch, tmp_path):
+        RunnerClass, runner = self._run_with_command("rf", monkeypatch, tmp_path)
+        runner.run_forward_migration_script.assert_called_once_with("0000000003")
+        runner.run_backward_migration_script.assert_not_called()
+        runner.create_migration_file.assert_not_called()
+
+    def test_run_dispatches_rb(self, monkeypatch, tmp_path):
+        RunnerClass, runner = self._run_with_command("rb", monkeypatch, tmp_path)
+        runner.run_backward_migration_script.assert_called_once_with()
+        runner.run_forward_migration_script.assert_not_called()
+
+    def test_run_dispatches_new(self, monkeypatch, tmp_path):
+        RunnerClass, runner = self._run_with_command("new", monkeypatch, tmp_path)
+        runner.create_migration_file.assert_called_once_with()
+
+    def test_run_dispatches_version(self, monkeypatch, tmp_path, capsys):
+        RunnerClass, runner = self._run_with_command("version", monkeypatch, tmp_path)
+        runner.run_forward_migration_script.assert_not_called()
+        runner.run_backward_migration_script.assert_not_called()
+        runner.create_migration_file.assert_not_called()
+
+    def test_run_unknown_command_prints_help(self, monkeypatch, tmp_path):
+        (tmp_path / "app" / "migrations").mkdir(parents=True)
+        monkeypatch.chdir(tmp_path)
+        monkeypatch.setenv("FOO", "fooval")
+        monkeypatch.setenv("BAR", "barval")
+
+        cli = _cli()
+        cli.parser = MagicMock()
+        cli.parser.parse_args.return_value = argparse.Namespace(
+            command=None,
+            env_files=[],
+            migrations_dir=None,
+        )
+
+        with patch(
+            "rococo.migrations.common.migration_runner.MigrationRunner"
+        ) as RunnerClass:
+            runner = RunnerClass.return_value
+            runner.get_db_version.return_value = "0000000000"
+            cli.run()
+
+        cli.parser.print_help.assert_called_once()

--- a/tests/migration_runner_test.py
+++ b/tests/migration_runner_test.py
@@ -458,6 +458,50 @@ class TestRunForwardMigrationScript:
         assert f"Error applying migration {script_name_no_ext}.py. Halting." in captured.out
         assert f"Current DB version after error: {initial_version}" in captured.out
 
+    def test_runs_long_chain_iteratively_without_stack_overflow(self, raw_runner, mocker):
+        """A deep migration history should iterate, not recurse. Many iterations
+        in a single call should not exceed Python's recursion limit."""
+        chain_length = 2000  # Well above default recursion limit (~1000)
+        script_names = [
+            f"{i + 1:010d}_{i:010d}_step_{i}" for i in range(chain_length)
+        ]
+        # Provide each script in turn, then None to terminate
+        mocker.patch.object(
+            raw_runner,
+            "_get_forward_migration_script",
+            side_effect=script_names + [None],
+        )
+        mocker.patch.object(raw_runner, "get_db_version", return_value=f"{chain_length:010d}")
+        mock_script_module = MagicMock()
+        mock_import_module = mocker.patch(
+            f"{MIGRATION_RUNNER_MODULE_PATH}.import_module",
+            return_value=mock_script_module,
+        )
+
+        raw_runner.run_forward_migration_script(initial_db_version_for_run="0000000000")
+
+        assert mock_import_module.call_count == chain_length
+        assert mock_script_module.upgrade.call_count == chain_length
+
+    def test_calls_invalidate_caches_before_import(self, raw_runner, mocker):
+        """importlib.invalidate_caches is called before each module import so
+        newly-added migration files in long-running processes are picked up."""
+        script_name = "0000000001_0000000000_first_migration"
+        mocker.patch.object(
+            raw_runner, "_get_forward_migration_script", side_effect=[script_name, None]
+        )
+        mocker.patch.object(raw_runner, "get_db_version", return_value="0000000001")
+        mocker.patch(
+            f"{MIGRATION_RUNNER_MODULE_PATH}.import_module", return_value=MagicMock()
+        )
+        invalidate_mock = mocker.patch(
+            f"{MIGRATION_RUNNER_MODULE_PATH}.importlib.invalidate_caches"
+        )
+
+        raw_runner.run_forward_migration_script(initial_db_version_for_run="0000000000")
+
+        invalidate_mock.assert_called_once()
+
 # --- Tests for run_backward_migration_script ---
 class TestRunBackwardMigrationScript:
 

--- a/tests/sql_migration_base_test.py
+++ b/tests/sql_migration_base_test.py
@@ -1,0 +1,330 @@
+"""Tests for SQLMigrationBase and its dialect subclasses (Postgres, MySQL).
+
+Verifies:
+- Identifier and PK-keys validation
+- Result-extraction helper
+- Shared method skeletons call execute with expected SQL + parameterized args
+- PostgresMigration and MySQLMigration produce dialect-correct SQL
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from rococo.migrations.common.sql_migration_base import SQLMigrationBase
+from rococo.migrations.postgres.migration import PostgresMigration
+from rococo.migrations.mysql.migration import MySQLMigration
+
+
+def _make_migration(cls):
+    adapter = MagicMock()
+    adapter._database = "testdb"
+    instance = cls(adapter)
+    instance.execute = MagicMock(return_value=None)
+    return instance, adapter
+
+
+# ---------- _validate_ident ----------
+
+class TestValidateIdent:
+    def setup_method(self):
+        self.m, _ = _make_migration(PostgresMigration)
+
+    @pytest.mark.parametrize("name", [
+        "users", "user_email_idx", "_temp", "T", "x1", "table_2025",
+    ])
+    def test_accepts_standard_identifiers(self, name):
+        assert self.m._validate_ident(name) == name
+
+    @pytest.mark.parametrize("name", [
+        "1table", "user-data", "user data", "user;DROP",
+        "drop table users", "", "ta'ble", "ta\"ble",
+    ])
+    def test_rejects_bad_identifiers(self, name):
+        with pytest.raises(ValueError, match="invalid SQL identifier"):
+            self.m._validate_ident(name)
+
+    @pytest.mark.parametrize("name", [None, 123, [], {}, b"users"])
+    def test_rejects_non_string(self, name):
+        with pytest.raises(ValueError, match="invalid SQL identifier"):
+            self.m._validate_ident(name)
+
+
+# ---------- _validate_pk_keys ----------
+
+class TestValidatePkKeys:
+    def setup_method(self):
+        self.m, _ = _make_migration(PostgresMigration)
+
+    @pytest.mark.parametrize("keys", [
+        "(id)", "(id, email)", "(id, name, created_at)", "(_a, _b)",
+    ])
+    def test_accepts_valid_keys(self, keys):
+        assert self.m._validate_pk_keys(keys) == keys
+
+    @pytest.mark.parametrize("keys", [
+        "id", "(id", "id)", "()1", "(id,)", "(1col)", "(col-name)",
+        "(col; DROP)", "",
+    ])
+    def test_rejects_invalid_keys(self, keys):
+        with pytest.raises(ValueError):
+            self.m._validate_pk_keys(keys)
+
+
+# ---------- _extract_count ----------
+
+class TestExtractCount:
+    def test_extracts_count_from_aliased_dict(self):
+        assert SQLMigrationBase._extract_count([{"count": 5}]) == 5
+
+    def test_extracts_count_from_mysql_style_key(self):
+        # When SQL has no alias and MySQL returns COUNT(*) literal as key
+        assert SQLMigrationBase._extract_count([{"COUNT(*)": 7}]) == 7
+
+    def test_zero_when_empty(self):
+        assert SQLMigrationBase._extract_count([]) == 0
+        assert SQLMigrationBase._extract_count(None) == 0
+        assert SQLMigrationBase._extract_count([{}]) == 0
+
+    def test_handles_none_value(self):
+        assert SQLMigrationBase._extract_count([{"count": None}]) == 0
+
+
+# ---------- Shared method behavior (Postgres) ----------
+
+class TestPostgresHelpers:
+    def setup_method(self):
+        self.m, self.adapter = _make_migration(PostgresMigration)
+
+    def test_does_column_exist_uses_parameterized_query(self):
+        self.m.execute = MagicMock(return_value=[{"count": 1}])
+        result = self.m._does_column_exist("users", "email")
+
+        assert result is True
+        sql, kwargs = self.m.execute.call_args.args[0], self.m.execute.call_args.kwargs
+        assert "information_schema.columns" in sql
+        assert "%s" in sql
+        assert kwargs["args"] == ("testdb", "users", "email")
+
+    def test_does_column_exist_returns_false_when_zero(self):
+        self.m.execute = MagicMock(return_value=[{"count": 0}])
+        assert self.m._does_column_exist("users", "email") is False
+
+    def test_does_pk_exists_uses_parameterized_query(self):
+        self.m.execute = MagicMock(return_value=[{"count": 1}])
+        self.m._does_primary_key_constraint_exists("users")
+        sql, kwargs = self.m.execute.call_args.args[0], self.m.execute.call_args.kwargs
+        assert "information_schema.table_constraints" in sql
+        assert "PRIMARY KEY" in sql
+        assert kwargs["args"] == ("testdb", "users")
+
+    def test_add_column_skips_when_exists(self):
+        self.m._does_column_exist = MagicMock(return_value=True)
+        self.m.add_column("users", "email", "VARCHAR(255)")
+        self.m.execute.assert_not_called()
+
+    def test_add_column_emits_pg_dialect(self):
+        self.m._does_column_exist = MagicMock(return_value=False)
+        self.m.add_column("users", "email", "VARCHAR(255)")
+        sql = self.m.execute.call_args.args[0]
+        assert sql == "ALTER TABLE users ADD COLUMN email VARCHAR(255);"
+
+    def test_drop_column_skips_when_missing(self):
+        self.m._does_column_exist = MagicMock(return_value=False)
+        self.m.drop_column("users", "email")
+        self.m.execute.assert_not_called()
+
+    def test_drop_column_emits_pg_dialect(self):
+        self.m._does_column_exist = MagicMock(return_value=True)
+        self.m.drop_column("users", "email")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users DROP COLUMN email;"
+
+    def test_alter_index_runs_drop_then_create(self):
+        self.m.alter_index("users", "new_idx", "email", "old_idx")
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == [
+            "DROP INDEX IF EXISTS old_idx;",
+            "CREATE INDEX new_idx ON users (email);",
+        ]
+
+    def test_add_index(self):
+        self.m.add_index("users", "email_idx", "email")
+        assert self.m.execute.call_args.args[0] == "CREATE INDEX email_idx ON users (email);"
+
+    def test_remove_index(self):
+        self.m.remove_index("users", "email_idx")
+        assert self.m.execute.call_args.args[0] == "DROP INDEX IF EXISTS email_idx;"
+
+    def test_alter_column(self):
+        self.m.alter_column("users", "email", "TEXT")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users ALTER COLUMN email TYPE TEXT;"
+
+    def test_change_column_name(self):
+        self.m.change_column_name("users", "email", "user_email")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users RENAME COLUMN email TO user_email;"
+
+    def test_change_table_name(self):
+        self.m.change_table_name("users", "people")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users RENAME TO people;"
+
+    def test_create_table_with_drop_uses_cascade(self):
+        self.m.create_table("users", "id INT PRIMARY KEY")
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == [
+            "DROP TABLE IF EXISTS users CASCADE;",
+            "CREATE TABLE users (id INT PRIMARY KEY);",
+        ]
+
+    def test_create_table_without_drop(self):
+        self.m.create_table("users", "id INT", drop_if_exists=False)
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == ["CREATE TABLE users (id INT);"]
+
+    def test_drop_table_uses_cascade(self):
+        self.m.drop_table("users")
+        assert self.m.execute.call_args.args[0] == "DROP TABLE users CASCADE;"
+
+    def test_remove_primary_key_emits_pg_dialect(self):
+        self.m._does_primary_key_constraint_exists = MagicMock(return_value=True)
+        self.m.remove_primary_key("users")
+        assert self.m.execute.call_args.args[0] == \
+            "ALTER TABLE users DROP CONSTRAINT IF EXISTS users_pkey;"
+
+    def test_remove_primary_key_skips_when_missing(self):
+        self.m._does_primary_key_constraint_exists = MagicMock(return_value=False)
+        self.m.remove_primary_key("users")
+        self.m.execute.assert_not_called()
+
+    def test_add_primary_key_drops_then_adds(self):
+        self.m._does_primary_key_constraint_exists = MagicMock(return_value=True)
+        self.m.add_primary_key("users", "(id, email)")
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == [
+            "ALTER TABLE users DROP CONSTRAINT IF EXISTS users_pkey;",
+            "ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY (id, email);",
+        ]
+
+    def test_add_primary_key_skips_drop_when_no_existing(self):
+        self.m._does_primary_key_constraint_exists = MagicMock(return_value=False)
+        self.m.add_primary_key("users", "(id)")
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == [
+            "ALTER TABLE users ADD CONSTRAINT users_pkey PRIMARY KEY (id);"
+        ]
+
+    def test_update_version_table_parameterizes_value(self):
+        self.m.update_version_table("0000000005")
+        sql = self.m.execute.call_args.args[0]
+        kwargs = self.m.execute.call_args.kwargs
+        assert sql == "UPDATE db_version SET version = %s;"
+        assert kwargs["args"] == ("0000000005",)
+
+    def test_insert_db_version_data(self):
+        self.m.insert_db_version_data()
+        assert self.m.execute.call_args.args[0] == \
+            "INSERT INTO db_version (version) VALUES ('0000000000');"
+
+
+# ---------- Shared method behavior (MySQL) ----------
+
+class TestMySQLDialect:
+    def setup_method(self):
+        self.m, self.adapter = _make_migration(MySQLMigration)
+
+    def test_does_column_exist_uses_mysql_schema_query(self):
+        self.m.execute = MagicMock(return_value=[{"count": 1}])
+        self.m._does_column_exist("users", "email")
+        sql, kwargs = self.m.execute.call_args.args[0], self.m.execute.call_args.kwargs
+        assert "information_schema.COLUMNS" in sql
+        assert "TABLE_SCHEMA" in sql
+        assert "%s" in sql
+        assert kwargs["args"] == ("testdb", "users", "email")
+
+    def test_add_column_uses_mysql_dialect(self):
+        self.m._does_column_exist = MagicMock(return_value=False)
+        self.m.add_column("users", "email", "VARCHAR(255)")
+        # MySQL: ADD (no COLUMN keyword)
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users ADD email VARCHAR(255);"
+
+    def test_drop_column_uses_mysql_dialect(self):
+        self.m._does_column_exist = MagicMock(return_value=True)
+        self.m.drop_column("users", "email")
+        # MySQL: DROP (no COLUMN keyword)
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users DROP email;"
+
+    def test_alter_index_is_atomic(self):
+        self.m.alter_index("users", "new_idx", "email", "old_idx")
+        # MySQL: single ALTER TABLE with both ADD INDEX and DROP INDEX
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == [
+            "ALTER TABLE users ADD INDEX new_idx (email), DROP INDEX old_idx;"
+        ]
+
+    def test_remove_index_uses_mysql_dialect(self):
+        self.m.remove_index("users", "email_idx")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users DROP INDEX email_idx;"
+
+    def test_add_index_uses_mysql_dialect(self):
+        self.m.add_index("users", "email_idx", "email")
+        assert self.m.execute.call_args.args[0] == \
+            "ALTER TABLE users ADD INDEX email_idx (email);"
+
+    def test_alter_column_uses_modify(self):
+        self.m.alter_column("users", "email", "TEXT")
+        assert self.m.execute.call_args.args[0] == \
+            "ALTER TABLE users MODIFY COLUMN email TEXT;"
+
+    def test_drop_table_no_cascade(self):
+        self.m.drop_table("users")
+        assert self.m.execute.call_args.args[0] == "DROP TABLE users;"
+
+    def test_create_table_with_drop_no_cascade(self):
+        self.m.create_table("users", "id INT")
+        calls = [c.args[0] for c in self.m.execute.call_args_list]
+        assert calls == [
+            "DROP TABLE IF EXISTS users;",
+            "CREATE TABLE users (id INT);",
+        ]
+
+    def test_remove_primary_key_uses_mysql_dialect(self):
+        self.m._does_primary_key_constraint_exists = MagicMock(return_value=True)
+        self.m.remove_primary_key("users")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users DROP PRIMARY KEY;"
+
+    def test_add_primary_key_uses_mysql_dialect(self):
+        self.m._does_primary_key_constraint_exists = MagicMock(return_value=False)
+        self.m.add_primary_key("users", "(id)")
+        assert self.m.execute.call_args.args[0] == "ALTER TABLE users ADD PRIMARY KEY (id);"
+
+
+# ---------- Identifier injection is blocked ----------
+
+class TestInjectionBlocked:
+    """All identifier-accepting methods must reject injection-shaped names."""
+
+    def setup_method(self):
+        self.m, _ = _make_migration(PostgresMigration)
+
+    def test_add_column_rejects_injection_in_table(self):
+        with pytest.raises(ValueError):
+            self.m.add_column("users; DROP TABLE users--", "email", "TEXT")
+
+    def test_add_column_rejects_injection_in_column(self):
+        with pytest.raises(ValueError):
+            self.m.add_column("users", "email'); DROP TABLE users--", "TEXT")
+
+    def test_drop_table_rejects_injection(self):
+        with pytest.raises(ValueError):
+            self.m.drop_table("users; DROP TABLE secrets")
+
+    def test_create_table_rejects_injection(self):
+        with pytest.raises(ValueError):
+            self.m.create_table("users; SELECT 1", "id INT")
+
+    def test_change_table_name_rejects_injection(self):
+        with pytest.raises(ValueError):
+            self.m.change_table_name("users", "people; DROP TABLE roles")
+
+    def test_add_primary_key_rejects_injection_in_keys(self):
+        with pytest.raises(ValueError):
+            self.m.add_primary_key("users", "(id); DROP TABLE users--")


### PR DESCRIPTION
## Describe your changes
Refactor the migration helpers:                                                                                                                                            
  - Extract shared logic from `postgres/migration.py` and `mysql/migration.py`
    into a new `SQLMigrationBase`. Each dialect is now ~40 lines of SQL templates.                                                                                           
  - Validate identifiers and parameterize values to close SQL-injection surface                                                                                              
    in the migration helpers.                                                                                                                                                
  - Convert recursive `run_forward_migration_script` to a `while` loop.                                                                                                      
  - Drop unused `_cursor_to_dict` from `MySQLMigration`. 

## Issue ticket number and link
N/A
## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings
N/A