### PR TITLE
fix: use correct PostgreSQL deadlock code and fix Mailjet init crashes

### DIFF
--- a/rococo/data/postgresql.py
+++ b/rococo/data/postgresql.py
@@ -419,8 +419,8 @@ class PostgreSQLAdapter(DbAdapter):
             return True
         except psycopg2.Error as ex:
             self._connection.rollback()
-            if retry_count < 3 and ex.args[0] == 1213:
-                # Deadlock detected
+            if retry_count < 3 and getattr(ex, 'pgcode', None) == '40P01':
+                # Deadlock detected (PostgreSQL SQLSTATE 40P01)
                 logging.warning("Deadlock detected on table %s. Retrying in %d seconds. Attempt %d",
                                 table_name, 2**retry_count, retry_count+1)
                 time.sleep(2**retry_count)

--- a/rococo/emailing/mailjet.py
+++ b/rococo/emailing/mailjet.py
@@ -71,8 +71,11 @@ class MailjetService(EmailService):
     def __call__(self, config: MailjetConfig, *args, **kwargs):
         super().__call__(config)
 
-        match = re.match(r'^(.*)\s*<(.*)>$', self.config.SOURCE_EMAIL)
-        name, email = match.groups()
+        match = re.match(r'^\s*(.*?)\s*<(.+)>\s*$', self.config.SOURCE_EMAIL)
+        if match:
+            name, email = match.groups()
+        else:
+            name, email = '', self.config.SOURCE_EMAIL.strip()
         self.from_address = {"Name": name, "Email": email}
 
         self.client = Client(
@@ -152,7 +155,7 @@ class MailjetService(EmailService):
             response_data = result.json()["Data"]
         except Exception as e:
             message = f"Couldn't find Mailjet contact for {email}: {e}"
-            logger.exception(message, "warning")
+            logger.exception(message)
             return
 
         for contact in response_data:
@@ -163,4 +166,4 @@ class MailjetService(EmailService):
                     self.config.MAILJET_API_KEY, self.config.MAILJET_API_SECRET), timeout=15)
             except Exception as e:
                 message = f"Couldn't remove Mailjet contact for {email} : {e}"
-                logger.exception(message, "warning")
+                logger.exception(message)

--- a/rococo/emailing/mailjet.py
+++ b/rococo/emailing/mailjet.py
@@ -71,6 +71,9 @@ class MailjetService(EmailService):
     def __call__(self, config: MailjetConfig, *args, **kwargs):
         super().__call__(config)
 
+        # Parse SOURCE_EMAIL which accepts two formats:
+        #   "Name <email@example.com>"  → {"Name": "Name", "Email": "email@example.com"}
+        #   "user@example.com"          → {"Name": "", "Email": "user@example.com"}
         match = re.match(r'^\s*(.*?)\s*<(.+)>\s*$', self.config.SOURCE_EMAIL)
         if match:
             name, email = match.groups()

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.3.1',
+    version='1.3.2',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',


### PR DESCRIPTION
## Fixes

### 1. PostgreSQL deadlock retry never triggered
`rococo/data/postgresql.py:422` checked `ex.args[0] == 1213` to detect deadlocks. `1213` is MySQLs `ER_LOCK_DEADLOCK`. With psycopg2, `ex.args[0]` is a string (the error message), not an integer code — so the branch was dead code. PostgreSQL deadlocks use SQLSTATE `40P01`, accessible via `ex.pgcode`.

**Before:** all deadlocks fell through to `raise ex` with no retry.
**After:** `getattr(ex, "pgcode", None) == "40P01"` triggers the exponential backoff retry.

### 2. MailjetService crashes on bare email addresses
`rococo/emailing/mailjet.py:74` regex assumed `Name <email>` format. A bare address like `user@example.com` returned `None`, and `.groups()` raised `AttributeError` at service init.

**Fix:** try the regex match first; fall back to using the raw string as the Email field.

### 3. logger.exception() with dangling second argument
Lines 155/166 passed `"warning"` as a second positional arg to `logger.exception()`, which uses it for printf interpolation. With no `%s` in the message, this caused `TypeError` silently swallowed by logging, dropping the intended messages.

**Fix:** remove the spurious second argument.