### PR TITLE
Atomic DynamoDB saves for `VersionedModel` records

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The following extras are available:
 - **data-mysql** - MySQL support
 - **data-mongo** - MongoDB support
 - **data-postgres** - PostgreSQL support
+- **data-dynamodb** - DynamoDB support
 - **messaging** - rabbitmq/sqs messaging
 - **emailing** - mailjet/ses emailing
 - **faxing** - iFax faxing support

--- a/docs/dynamo_db_usage.md
+++ b/docs/dynamo_db_usage.md
@@ -102,12 +102,14 @@ It sets up the following schema:
 *   **Attributes**: Mapped from your dataclass fields.
 
 ### Audit Tables
-If you update a record, the adapter automatically moves the old version to an audit table (e.g., `person_audit`).
+If you update a versioned record, the adapter automatically writes the old version to an audit table (e.g., `person_audit`) and writes the new current version.
 *   **Audit Table Name**: `{table_name}_audit`
 *   **Hash Key**: `entity_id`
 *   **Range Key**: `version`
 
 Ensure your DynamoDB tables are created with these key schemas if you are provisioning them manually.
+
+Versioned saves use DynamoDB `TransactWriteItems` for the audit-table write and main-table write. For existing entities, the main-table write is conditional on the current row's `version` matching the model's `previous_version`; if another writer has already advanced the version, the save raises `DynamoDbOptimisticLockError` and neither write is committed. New versioned entities are also conditionally inserted so a reused `entity_id` cannot overwrite an existing item.
 
 ## Example Application
 

--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -1,10 +1,16 @@
 from typing import Any, Dict, List, Optional, Tuple, Type, Union
 import os
 from pynamodb.models import Model
-from pynamodb.attributes import UnicodeAttribute, BooleanAttribute, NumberAttribute, JSONAttribute, UTCDateTimeAttribute, ListAttribute
-from pynamodb.exceptions import DoesNotExist
+from pynamodb.attributes import UnicodeAttribute, BooleanAttribute, NumberAttribute, JSONAttribute, ListAttribute
+from pynamodb.exceptions import DoesNotExist, TransactWriteError
+from pynamodb.transactions import TransactWrite
 from rococo.data.base import DbAdapter
 from rococo.models import BaseModel, VersionedModel
+from rococo.models.versioned_model import get_uuid_hex
+
+
+class DynamoDbOptimisticLockError(RuntimeError):
+    """Raised when a DynamoDB versioned save loses its optimistic lock."""
 
 
 class DynamoDbAdapter(DbAdapter):
@@ -51,6 +57,7 @@ class DynamoDbAdapter(DbAdapter):
             'Meta': type('Meta', (), {
                 'table_name': Meta.table_name_val,
                 'region': Meta.region,
+                'host': os.getenv('DYNAMODB_ENDPOINT_URL'),
                 'aws_access_key_id': Meta.aws_access_key_id,
                 'aws_secret_access_key': Meta.aws_secret_access_key
             })
@@ -167,6 +174,116 @@ class DynamoDbAdapter(DbAdapter):
         item = pynamo_model(**data)
         item.save()
         return item.attribute_values
+
+    def save_versioned(
+        self,
+        table: str,
+        data: Dict[str, Any],
+        model_cls: Type[VersionedModel] = None,
+        write_audit: bool = True
+    ) -> Union[Dict[str, Any], None]:
+        """
+        Atomically save a VersionedModel item and its audit record.
+
+        Existing entities are saved with optimistic locking: the current table
+        row must still have the version carried in ``data['previous_version']``.
+        If that condition fails, no write is committed. When ``write_audit`` is
+        true, the audit row and current row are committed in the same
+        transaction. New entities are conditionally inserted so an accidental
+        reused ``entity_id`` cannot overwrite an existing item.
+        """
+        if model_cls is None:
+            raise ValueError("model_cls is required for DynamoDB save_versioned")
+
+        entity_id = data.get('entity_id')
+        previous_version = data.get('previous_version')
+        if not entity_id:
+            raise RuntimeError("save_versioned failed: 'entity_id' is required in data")
+        if not data.get('version'):
+            raise RuntimeError("save_versioned failed: 'version' is required in data")
+
+        pynamo_model = self._generate_pynamo_model(table, model_cls)
+        item = pynamo_model(**data)
+
+        try:
+            if self._is_initial_version(previous_version):
+                with TransactWrite(connection=pynamo_model._get_connection().connection) as transaction:
+                    transaction.save(
+                        item,
+                        condition=pynamo_model.entity_id.does_not_exist()
+                    )
+                return item.attribute_values
+
+            current_version_condition = pynamo_model.version == previous_version
+
+            audit_item = None
+            audit_condition = None
+            if write_audit:
+                current_values = self._get_current_version_for_audit(
+                    pynamo_model,
+                    entity_id,
+                    previous_version
+                )
+                audit_table_name = f"{table}_audit"
+                pynamo_audit_model = self._generate_pynamo_model(
+                    audit_table_name,
+                    model_cls,
+                    is_audit=True
+                )
+                audit_item = pynamo_audit_model(**current_values)
+                audit_condition = (
+                    pynamo_audit_model.entity_id.does_not_exist()
+                    & pynamo_audit_model.version.does_not_exist()
+                )
+
+            with TransactWrite(connection=pynamo_model._get_connection().connection) as transaction:
+                if audit_item is not None:
+                    transaction.save(audit_item, condition=audit_condition)
+
+                transaction.save(item, condition=current_version_condition)
+            return item.attribute_values
+        except DynamoDbOptimisticLockError:
+            raise
+        except TransactWriteError as e:
+            if self._is_optimistic_lock_failure(e):
+                raise DynamoDbOptimisticLockError(
+                    f"Version conflict while saving entity_id={entity_id} to {table}"
+                ) from e
+            raise RuntimeError(f"save_versioned failed: {e}") from e
+        except Exception as e:
+            raise RuntimeError(f"save_versioned failed: {e}") from e
+
+    @staticmethod
+    def _is_initial_version(previous_version: Any) -> bool:
+        return previous_version in (None, get_uuid_hex(0))
+
+    @staticmethod
+    def _is_optimistic_lock_failure(error: TransactWriteError) -> bool:
+        return any(
+            reason is not None and reason.code == 'ConditionalCheckFailed'
+            for reason in error.cancellation_reasons
+        )
+
+    @staticmethod
+    def _get_current_version_for_audit(
+        pynamo_model: Type[Model],
+        entity_id: str,
+        expected_version: str
+    ) -> Dict[str, Any]:
+        try:
+            current_item = pynamo_model.get(entity_id, consistent_read=True)
+        except DoesNotExist as e:
+            raise DynamoDbOptimisticLockError(
+                f"Cannot update missing DynamoDB entity_id={entity_id}"
+            ) from e
+
+        current_values = current_item.attribute_values.copy()
+        current_version = current_values.get('version')
+        if current_version != expected_version:
+            raise DynamoDbOptimisticLockError(
+                f"Version conflict for entity_id={entity_id}: expected {expected_version}, found {current_version}"
+            )
+        return current_values
 
     def upsert(self, table: str, data: Dict[str, Any], model_cls: Type[BaseModel] = None) -> Union[Dict[str, Any], None]:
         """

--- a/rococo/repositories/dynamodb/dynamodb_repository.py
+++ b/rococo/repositories/dynamodb/dynamodb_repository.py
@@ -1,11 +1,11 @@
 import json
 import logging
 from uuid import UUID
-from typing import Any, Dict, List, Optional, Type, Tuple
+from typing import Any, Dict, List, Optional, Type, Tuple, Union
 from rococo.data.dynamodb import DynamoDbAdapter
 from rococo.messaging import MessageAdapter
 from rococo.repositories import BaseRepository
-from rococo.models.versioned_model import BaseModel, VersionedModel, get_uuid_hex
+from rococo.models.versioned_model import BaseModel
 
 
 class DynamoDbRepository(BaseRepository):
@@ -111,33 +111,14 @@ class DynamoDbRepository(BaseRepository):
 
         # Use appropriate save method based on model type
         if self._is_versioned_model():
-            # For versioned models, move existing version to audit if needed
-            if self.use_audit_table:
-                previous_version = getattr(instance, 'previous_version', None)
-                if previous_version and previous_version != get_uuid_hex(0):
-                    self._execute_within_context(
-                        lambda: self.adapter.move_entity_to_audit_table(
-                            self.table_name,
-                            instance.entity_id,
-                            model_cls=self.model
-                        )
-                    )
-
-            # Save with versioning
-            saved = self._execute_within_context(
-                lambda: self.adapter.save(self.table_name, payload, model_cls=self.model)
-            )
+            saved = self._save_versioned(payload)
         else:
             # For non-versioned models, use simple upsert
             saved = self._execute_within_context(
                 lambda: self.adapter.upsert(self.table_name, payload, model_cls=self.model)
             )
 
-        # Hydrate the returned fields onto our instance
-        if saved:
-            for k, v in saved.items():
-                if hasattr(instance, k):
-                    setattr(instance, k, v)
+        self._hydrate_instance(instance, saved)
 
         # Send a message if requested
         if send_message:
@@ -148,6 +129,29 @@ class DynamoDbRepository(BaseRepository):
             )
 
         return instance
+
+    def _save_versioned(
+        self,
+        payload: Dict[str, Any]
+    ) -> Union[Dict[str, Any], None]:
+        return self._execute_within_context(
+            lambda: self.adapter.save_versioned(
+                self.table_name,
+                payload,
+                model_cls=self.model,
+                write_audit=self.use_audit_table
+            )
+        )
+
+    @staticmethod
+    def _hydrate_instance(
+        instance: BaseModel,
+        saved: Union[Dict[str, Any], None]
+    ) -> None:
+        if saved:
+            for k, v in saved.items():
+                if hasattr(instance, k):
+                    setattr(instance, k, v)
 
     def delete(
         self,
@@ -175,30 +179,8 @@ class DynamoDbRepository(BaseRepository):
             data = instance.as_dict(
                 convert_datetime_to_iso_string=True, convert_uuids=True, export_properties=self.save_calculated_fields)
 
-            # Move to audit if needed
-            if self.use_audit_table:
-                previous_version = getattr(instance, 'previous_version', None)
-                if previous_version and previous_version != get_uuid_hex(0):
-                    self._execute_within_context(
-                        lambda: self.adapter.move_entity_to_audit_table(
-                            self.table_name,
-                            data['entity_id'],
-                            model_cls=self.model
-                        )
-                    )
-
-            saved = self._execute_within_context(
-                lambda: self.adapter.save(
-                    self.table_name,
-                    data,
-                    model_cls=self.model
-                )
-            )
-
-            if saved:
-                for k, v in saved.items():
-                    if hasattr(instance, k):
-                        setattr(instance, k, v)
+            saved = self._save_versioned(data)
+            self._hydrate_instance(instance, saved)
         else:
             # Hard delete for non-versioned models
             with self.adapter:

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ extras_require["all"] = [
 
 setup(
     name='rococo',
-    version='1.3.2',
+    version='1.3.3',
     packages=find_packages(),
     url='https://github.com/EcorRouge/rococo',
     license='MIT',

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -6,7 +6,8 @@ from unittest.mock import MagicMock, patch, ANY
 from typing import Type
 from pynamodb.models import Model
 from pynamodb.attributes import UnicodeAttribute, BooleanAttribute
-from rococo.data.dynamodb import DynamoDbAdapter
+from pynamodb.exceptions import TransactWriteError
+from rococo.data.dynamodb import DynamoDbAdapter, DynamoDbOptimisticLockError
 from rococo.repositories.dynamodb.dynamodb_repository import DynamoDbRepository
 from rococo.models.versioned_model import VersionedModel
 from rococo.messaging import MessageAdapter
@@ -57,6 +58,29 @@ class PersonAuditModel(Model):
     def save(self):
         pass
 
+
+class FakeTransactWrite:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.save = MagicMock()
+        self.__class__.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        return False
+
+
+class FailingTransactWrite(FakeTransactWrite):
+    def __exit__(self, exc_type, exc_value, traceback):
+        if exc_type is None:
+            raise TransactWriteError("transaction cancelled")
+        return False
+
 # Dummy Rococo Model
 @dataclass
 class Person(VersionedModel):
@@ -82,6 +106,7 @@ class TestDynamoDbRepository(unittest.TestCase):
 
     def tearDown(self):
         self.patcher.stop()
+        FakeTransactWrite.instances.clear()
 
     def _mock_generate_model(self, table_name, model_cls, is_audit=False):
         if is_audit:
@@ -143,11 +168,12 @@ class TestDynamoDbRepository(unittest.TestCase):
         # Test saving a new record
         person = Person(first_name='Jane', last_name='Doe')
         
-        with patch.object(PersonModel, 'save') as mock_save:
+        with patch('rococo.data.dynamodb.TransactWrite', FakeTransactWrite):
             saved_person = self.repository.save(person, send_message=True)
             
             self.assertEqual(saved_person.first_name, 'Jane')
-            mock_save.assert_called()
+            self.assertEqual(len(FakeTransactWrite.instances), 1)
+            FakeTransactWrite.instances[0].save.assert_called_once()
             
             # Verify message was sent
             self.message_adapter.send_message.assert_called_with(
@@ -164,36 +190,107 @@ class TestDynamoDbRepository(unittest.TestCase):
         person.version = old_version  # Set version so prepare_for_save preserves it in previous_version
         person.previous_version = old_version
         
-        # Mock the 'get' call used by move_entity_to_audit_table
+        # Mock the consistent read used to build the audit record.
         with patch.object(PersonModel, 'get') as mock_get:
             mock_item = MagicMock()
-            mock_item.attribute_values = {'entity_id': entity_id, 'first_name': 'Jane', 'active': True}
+            mock_item.attribute_values = {
+                'entity_id': entity_id,
+                'version': old_version,
+                'first_name': 'Jane',
+                'active': True
+            }
             mock_get.return_value = mock_item
             
-            with patch.object(PersonAuditModel, 'save') as mock_audit_save:
-                with patch.object(PersonModel, 'save') as mock_save:
-                    self.repository.save(person, send_message=True)
-                    
-                    # Ensure we tried to fetch the old record to audit it
-                    mock_get.assert_called_with(entity_id)
-                    
-                    # Ensure the audit record was saved
-                    mock_audit_save.assert_called()
-                    
-                    # Ensure the new record was saved
-                    mock_save.assert_called()
-                    
-                    # Verify message was sent
-                    self.message_adapter.send_message.assert_called()
+            with patch('rococo.data.dynamodb.TransactWrite', FakeTransactWrite):
+                self.repository.save(person, send_message=True)
+
+                # Ensure we fetched the current row consistently before the transaction.
+                mock_get.assert_called_with(entity_id, consistent_read=True)
+
+                # One transaction should contain the audit put and the main-table put.
+                self.assertEqual(len(FakeTransactWrite.instances), 1)
+                self.assertEqual(FakeTransactWrite.instances[0].save.call_count, 2)
+
+                # Verify message was sent
+                self.message_adapter.send_message.assert_called()
+
+    def test_save_existing_stale_version_raises_optimistic_lock_error(self):
+        person = Person(first_name='Jane', last_name='Doe')
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+        concurrent_version = uuid4().hex
+        person.entity_id = entity_id
+        person.version = old_version
+        person.previous_version = old_version
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            mock_item = MagicMock()
+            mock_item.attribute_values = {
+                'entity_id': entity_id,
+                'version': concurrent_version,
+                'first_name': 'Concurrent',
+                'active': True
+            }
+            mock_get.return_value = mock_item
+
+            with patch('rococo.data.dynamodb.TransactWrite', FakeTransactWrite):
+                with self.assertRaises(DynamoDbOptimisticLockError):
+                    self.repository.save(person)
+
+                self.assertEqual(len(FakeTransactWrite.instances), 0)
+
+    def test_save_existing_transaction_condition_failure_raises_optimistic_lock_error(self):
+        person = Person(first_name='Jane', last_name='Doe')
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+        person.entity_id = entity_id
+        person.version = old_version
+        person.previous_version = old_version
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            mock_item = MagicMock()
+            mock_item.attribute_values = {
+                'entity_id': entity_id,
+                'version': old_version,
+                'first_name': 'Jane',
+                'active': True
+            }
+            mock_get.return_value = mock_item
+
+            with patch('rococo.data.dynamodb.TransactWrite', FailingTransactWrite):
+                with patch.object(self.adapter, '_is_optimistic_lock_failure', return_value=True):
+                    with self.assertRaises(DynamoDbOptimisticLockError):
+                        self.repository.save(person)
+
+                self.assertEqual(len(FailingTransactWrite.instances), 1)
+                self.assertEqual(FailingTransactWrite.instances[0].save.call_count, 2)
+
+    def test_save_existing_without_audit_still_uses_optimistic_transaction(self):
+        self.repository.use_audit_table = False
+        person = Person(first_name='Jane', last_name='Doe')
+        entity_id = uuid4().hex
+        old_version = uuid4().hex
+        person.entity_id = entity_id
+        person.version = old_version
+        person.previous_version = old_version
+
+        with patch.object(PersonModel, 'get') as mock_get:
+            with patch('rococo.data.dynamodb.TransactWrite', FakeTransactWrite):
+                self.repository.save(person)
+
+                mock_get.assert_not_called()
+                self.assertEqual(len(FakeTransactWrite.instances), 1)
+                FakeTransactWrite.instances[0].save.assert_called_once()
 
     def test_delete(self):
         person = Person(first_name='Jane')
         person.entity_id = uuid4().hex
         
-        # Mock get for the delete check (if repository does a check) or just the save (soft delete)
-        with patch.object(PersonModel, 'save') as mock_save:
-             self.repository.delete(person)
-             mock_save.assert_called()
+        with patch('rococo.data.dynamodb.TransactWrite', FakeTransactWrite):
+            self.repository.delete(person)
+            self.assertFalse(person.active)
+            self.assertEqual(len(FakeTransactWrite.instances), 1)
+            FakeTransactWrite.instances[0].save.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
# Describe your changes
## Summary

Adds atomic DynamoDB saves for `VersionedModel` records.

Versioned DynamoDB saves now use `TransactWriteItems` so the audit-table write and main-table write commit together. Existing records are protected with optimistic locking: the current DynamoDB row must still match the model’s `previous_version`, otherwise the save fails with `DynamoDbOptimisticLockError` and no write is committed.

## Changes

- Added `DynamoDbAdapter.save_versioned()` for transactional versioned saves.
- Added `DynamoDbOptimisticLockError` for stale/concurrent update conflicts.
- Updated `DynamoDbRepository.save()` and versioned soft delete to use the transactional versioned-save path.
- Kept non-versioned DynamoDB models on normal upsert/hard-delete behavior.
- Added conditional insert protection for new versioned records.
- Wired `DYNAMODB_ENDPOINT_URL` into generated PynamoDB models.
- Added tests for transactional saves, stale version conflicts, transaction condition failures, and no-audit optimistic saves.
- Updated DynamoDB docs and README extras list.
## Issue ticket number and link

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have bumped version (in `setup.py`)

## Demonstrative Screenshots / Video Recordings

(if needed and available)