### PR TITLE
fix: DynamoDB adapter ignores offset in get_many — pagination returns wrong results

### DIFF
--- a/rococo/data/dynamodb.py
+++ b/rococo/data/dynamodb.py
@@ -115,13 +115,13 @@ class DynamoDbAdapter(DbAdapter):
         except Exception as e:
              raise RuntimeError(f"get_one failed: {e}")
 
-    def get_many(self, table: str, conditions: Dict[str, Any] = None, sort: List[Tuple[str, str]] = None, limit: int = 100, model_cls: Type[BaseModel] = None) -> List[Dict[str, Any]]:
+    def get_many(self, table: str, conditions: Dict[str, Any] = None, sort: List[Tuple[str, str]] = None, limit: int = 100, offset: int = None, model_cls: Type[BaseModel] = None) -> List[Dict[str, Any]]:
         if model_cls is None:
             raise ValueError("model_cls is required for DynamoDB get_many")
 
         pynamo_model = self._generate_pynamo_model(table, model_cls)
         try:
-            results = self._execute_query_or_scan(pynamo_model, conditions, limit=limit)
+            results = self._execute_query_or_scan(pynamo_model, conditions, limit=limit, offset=offset)
             return [item.attribute_values for item in results]
         except Exception as e:
             raise RuntimeError(f"get_many failed: {e}")
@@ -230,14 +230,14 @@ class DynamoDbAdapter(DbAdapter):
         except DoesNotExist:
             return False
 
-    def _execute_query_or_scan(self, model_cls: Type[Model], conditions: Dict[str, Any], limit: int = None, count_only: bool = False):
+    def _execute_query_or_scan(self, model_cls: Type[Model], conditions: Dict[str, Any], limit: int = None, offset: int = None, count_only: bool = False):
         """
         Helper to determine whether to use Query or Scan based on conditions.
         """
         # Find hash key and range key using public API instead of _meta
         hash_key_name = None
         range_key_name = None
-        
+
         for name, attr in model_cls.get_attributes().items():
             if getattr(attr, 'is_hash_key', False):
                 hash_key_name = name
@@ -245,19 +245,24 @@ class DynamoDbAdapter(DbAdapter):
                 range_key_name = name
 
         hash_key_val = conditions.get(hash_key_name) if conditions else None
-        
+
+        # DynamoDB has no native integer offset; fetch limit+offset and skip client-side.
+        effective_limit = limit
+        if limit is not None and offset:
+            effective_limit = limit + offset
+
         if hash_key_val is not None:
             # Query path: Hash key is present
             range_key_condition = None
             filter_condition = None
-            
+
             for key, value in conditions.items():
                 if key == hash_key_name:
                     continue
-                
+
                 attr = getattr(model_cls, key)
                 cond = (attr == value)
-                
+
                 if key == range_key_name:
                     range_key_condition = cond
                 else:
@@ -265,11 +270,12 @@ class DynamoDbAdapter(DbAdapter):
                         filter_condition = cond
                     else:
                         filter_condition = filter_condition & cond
-            
+
             if count_only:
                 return model_cls.count(hash_key_val, range_key_condition=range_key_condition, filter_condition=filter_condition)
             else:
-                return model_cls.query(hash_key_val, range_key_condition=range_key_condition, filter_condition=filter_condition, limit=limit)
+                results = model_cls.query(hash_key_val, range_key_condition=range_key_condition, filter_condition=filter_condition, limit=effective_limit)
+                return self._apply_offset(results, offset, limit)
         else:
             # Scan path: Hash key is missing
             scan_condition = None
@@ -281,8 +287,26 @@ class DynamoDbAdapter(DbAdapter):
                         scan_condition = cond
                     else:
                         scan_condition = scan_condition & cond
-            
+
             if count_only:
                 return model_cls.count(filter_condition=scan_condition)
             else:
-                return model_cls.scan(scan_condition, limit=limit)
+                results = model_cls.scan(scan_condition, limit=effective_limit)
+                return self._apply_offset(results, offset, limit)
+
+    def _apply_offset(self, results, offset, limit):
+        """Skip `offset` items from a PynamoDB result iterator, then collect up to `limit`."""
+        if not offset:
+            return results
+        iterator = iter(results)
+        for _ in range(offset):
+            try:
+                next(iterator)
+            except StopIteration:
+                return []
+        collected = []
+        for item in iterator:
+            collected.append(item)
+            if limit is not None and len(collected) >= limit:
+                break
+        return collected

--- a/rococo/repositories/dynamodb/dynamodb_repository.py
+++ b/rococo/repositories/dynamodb/dynamodb_repository.py
@@ -88,6 +88,7 @@ class DynamoDbRepository(BaseRepository):
                 conditions=db_conditions,
                 sort=sort,
                 limit=limit,
+                offset=offset,
                 model_cls=self.model
             )
         )

--- a/tests/dynamodb_repository_test.py
+++ b/tests/dynamodb_repository_test.py
@@ -186,6 +186,96 @@ class TestDynamoDbRepository(unittest.TestCase):
                     # Verify message was sent
                     self.message_adapter.send_message.assert_called()
 
+    def _mock_person_items(self, count):
+        items = []
+        for i in range(count):
+            mock_item = MagicMock()
+            mock_item.attribute_values = {
+                'entity_id': uuid4().hex,
+                'first_name': f'Person{i}',
+                'active': True,
+            }
+            items.append(mock_item)
+        return items
+
+    def test_get_many_no_offset(self):
+        # When offset is not provided, behavior should be identical to before:
+        # adapter must not request extra items and should return everything fetched.
+        PersonModel.get_attributes = MagicMock()
+        mock_hash_attr = MagicMock()
+        mock_hash_attr.is_hash_key = True
+        mock_hash_attr.is_range_key = False
+        PersonModel.get_attributes.return_value = {'entity_id': mock_hash_attr}
+
+        items = self._mock_person_items(3)
+
+        with patch.object(PersonModel, 'scan') as mock_scan:
+            mock_scan.return_value = items
+            results = self.repository.get_many({'first_name': 'Person0'}, limit=10)
+
+            self.assertEqual(len(results), 3)
+            # scan should be called with the raw limit (no offset added)
+            _, kwargs = mock_scan.call_args
+            self.assertEqual(kwargs.get('limit'), 10)
+
+    def test_get_many_with_offset_scan(self):
+        # Scan path: offset=2, limit=2 should fetch 4 and return items [2..4).
+        PersonModel.get_attributes = MagicMock()
+        mock_hash_attr = MagicMock()
+        mock_hash_attr.is_hash_key = True
+        mock_hash_attr.is_range_key = False
+        PersonModel.get_attributes.return_value = {'entity_id': mock_hash_attr}
+
+        items = self._mock_person_items(5)
+        expected_first_names = [items[2].attribute_values['first_name'],
+                                items[3].attribute_values['first_name']]
+
+        with patch.object(PersonModel, 'scan') as mock_scan:
+            mock_scan.return_value = iter(items[:4])  # adapter requested limit+offset=4
+            results = self.repository.get_many({'first_name': 'X'}, limit=2, offset=2)
+
+            self.assertEqual(len(results), 2)
+            self.assertEqual([r.first_name for r in results], expected_first_names)
+            _, kwargs = mock_scan.call_args
+            self.assertEqual(kwargs.get('limit'), 4)
+
+    def test_get_many_with_offset_query(self):
+        # Query path (hash key present): offset must be applied client-side.
+        PersonModel.get_attributes = MagicMock()
+        mock_hash_attr = MagicMock()
+        mock_hash_attr.is_hash_key = True
+        mock_hash_attr.is_range_key = False
+        PersonModel.get_attributes.return_value = {'entity_id': mock_hash_attr}
+
+        entity_id = uuid4().hex
+        items = self._mock_person_items(5)
+
+        with patch.object(PersonModel, 'query') as mock_query:
+            mock_query.return_value = iter(items[:3])  # limit+offset=3
+            results = self.repository.get_many({'entity_id': entity_id}, limit=2, offset=1)
+
+            self.assertEqual(len(results), 2)
+            self.assertEqual(results[0].first_name, items[1].attribute_values['first_name'])
+            self.assertEqual(results[1].first_name, items[2].attribute_values['first_name'])
+            _, kwargs = mock_query.call_args
+            self.assertEqual(kwargs.get('limit'), 3)
+
+    def test_get_many_offset_exceeds_results(self):
+        # When offset >= total items returned, should produce an empty list.
+        PersonModel.get_attributes = MagicMock()
+        mock_hash_attr = MagicMock()
+        mock_hash_attr.is_hash_key = True
+        mock_hash_attr.is_range_key = False
+        PersonModel.get_attributes.return_value = {'entity_id': mock_hash_attr}
+
+        items = self._mock_person_items(2)
+
+        with patch.object(PersonModel, 'scan') as mock_scan:
+            mock_scan.return_value = iter(items)
+            results = self.repository.get_many({'first_name': 'X'}, limit=5, offset=10)
+
+            self.assertEqual(results, [])
+
     def test_delete(self):
         person = Person(first_name='Jane')
         person.entity_id = uuid4().hex


### PR DESCRIPTION
## Summary

`DynamoDbAdapter.get_many()` did not accept or process the `offset` parameter. When `DynamoDbRepository.get_many()` was called with `offset=N`, the value was silently discarded — every call returned results starting from the first record, making pagination unusable for DynamoDB-backed repositories.

All other database adapters (MySQL, PostgreSQL, MongoDB) properly forward and apply offset. This brings DynamoDB into compliance with the `BaseRepository` contract.

## Implementation

DynamoDB Scan/Query don't support integer offset natively, so we request `limit + offset` items from DynamoDB and skip the first `offset` items client-side via a new `_apply_offset()` helper. When offset is falsy (0/None), the original iterator is returned unchanged — zero performance regression for the common case.

### Changes

- **`rococo/data/dynamodb.py`**: Added `offset` parameter (default `None`) to `get_many()` and `_execute_query_or_scan()`. New `_apply_offset()` method on `DynamoDbAdapter` handles the client-side skip logic.
- **`rococo/repositories/dynamodb/dynamodb_repository.py`**: Added `offset=offset` forwarding in `get_many()` adapter call.
- **`tests/dynamodb_repository_test.py`**: Added 4 tests (scan path, query path, no-offset regression guard, offset-exceeds-results).

## Testing

```
python -m pytest tests/dynamodb_repository_test.py -v -k 'offset'  # 4/4 pass
python -m pytest tests/  # 375 pass (9 pre-existing fixture-related failures unchanged)
```

## Edge cases handled

- **offset=0 or None**: Original iterator returned, no materialization overhead
- **offset >= result count**: Returns empty list
- **Query and Scan paths**: Both covered with specific tests
- **No limit provided**: `effective_limit` stays `None` (fetch all, then slice)